### PR TITLE
feat: input component 생성 및 구현 (#9)

### DIFF
--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -2,15 +2,12 @@ import React, { forwardRef } from 'react';
 import { cn } from '@/utils/cn';
 import { INPUT_SIZES, INPUT_VARIANTS } from '@/constants/input/input';
 
-interface InputProps
-  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
-  error?: string;
-  success?: boolean;
-  successMessage?: string;
+interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  error?: boolean | string;
+  success?: boolean | string;
   label?: string;
-  helperText?: string;
   variant?: keyof typeof INPUT_VARIANTS;
-  size?: keyof typeof INPUT_SIZES;
+  inputSize?: keyof typeof INPUT_SIZES;
   containerClassName?: string;
 }
 
@@ -22,11 +19,9 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
       className = '',
       error,
       success,
-      successMessage,
       label,
-      helperText,
       variant = 'default',
-      size = 'md',
+      inputSize = 'md',
       containerClassName = '',
       ...props
     },
@@ -39,11 +34,14 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
       return variant;
     };
 
-    const hasMessage = error || (success && successMessage) || helperText;
+    const errorMessage = typeof error === 'string' ? error : '';
+    const successMessage = typeof success === 'string' ? success : '';
+    const message = errorMessage || successMessage;
+
     return (
       <div className={cn('w-full', containerClassName)}>
         {label && (
-          <label className="block text-sm font-medium text-black mb-2">
+          <label className="mb-2 block text-sm font-medium text-black">
             {label}
           </label>
         )}
@@ -54,10 +52,10 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
             type={type}
             disabled={disabled}
             className={cn(
-              'w-full border-2 rounded-lg',
+              'w-full rounded-lg border-2',
               'transition-colors duration-200 focus:outline-none',
               'font-pretendard text-base placeholder:text-gray-400',
-              INPUT_SIZES[size],
+              INPUT_SIZES[inputSize],
               INPUT_VARIANTS[getVariant()],
               className
             )}
@@ -65,18 +63,15 @@ const Input = forwardRef<HTMLInputElement, InputProps>(
           />
         </div>
 
-        {hasMessage && (
-          <div className="mt-3 transition-all duration-200">
-            {error && <p className="text-sm text-red-600">{error}</p>}
-
-            {success && successMessage && !error && (
-              <p className="text-sm text-green-600">{successMessage}</p>
+        {message && (
+          <p
+            className={cn(
+              'mt-2 text-sm',
+              errorMessage ? 'text-red-400' : 'text-green-600'
             )}
-
-            {helperText && !error && !successMessage && (
-              <p className="text-sm text-black">{helperText}</p>
-            )}
-          </div>
+          >
+            {message}
+          </p>
         )}
       </div>
     );

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,0 +1,88 @@
+import React, { forwardRef } from 'react';
+import { cn } from '@/utils/cn';
+import { INPUT_SIZES, INPUT_VARIANTS } from '@/constants/input/input';
+
+interface InputProps
+  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'size'> {
+  error?: string;
+  success?: boolean;
+  successMessage?: string;
+  label?: string;
+  helperText?: string;
+  variant?: keyof typeof INPUT_VARIANTS;
+  size?: keyof typeof INPUT_SIZES;
+  containerClassName?: string;
+}
+
+const Input = forwardRef<HTMLInputElement, InputProps>(
+  (
+    {
+      type = 'text',
+      disabled = false,
+      className = '',
+      error,
+      success,
+      successMessage,
+      label,
+      helperText,
+      variant = 'default',
+      size = 'md',
+      containerClassName = '',
+      ...props
+    },
+    ref
+  ) => {
+    const getVariant = (): keyof typeof INPUT_VARIANTS => {
+      if (disabled) return 'disabled';
+      if (error) return 'error';
+      if (success) return 'success';
+      return variant;
+    };
+
+    const hasMessage = error || (success && successMessage) || helperText;
+    return (
+      <div className={cn('w-full', containerClassName)}>
+        {label && (
+          <label className="block text-sm font-medium text-black mb-2">
+            {label}
+          </label>
+        )}
+
+        <div className="relative w-full">
+          <input
+            ref={ref}
+            type={type}
+            disabled={disabled}
+            className={cn(
+              'w-full border-2 rounded-lg',
+              'transition-colors duration-200 focus:outline-none',
+              'font-pretendard text-base placeholder:text-gray-400',
+              INPUT_SIZES[size],
+              INPUT_VARIANTS[getVariant()],
+              className
+            )}
+            {...props}
+          />
+        </div>
+
+        {hasMessage && (
+          <div className="mt-3 transition-all duration-200">
+            {error && <p className="text-sm text-red-600">{error}</p>}
+
+            {success && successMessage && !error && (
+              <p className="text-sm text-green-600">{successMessage}</p>
+            )}
+
+            {helperText && !error && !successMessage && (
+              <p className="text-sm text-black">{helperText}</p>
+            )}
+          </div>
+        )}
+      </div>
+    );
+  }
+);
+
+Input.displayName = 'Input';
+
+export default Input;

--- a/src/constants/input/input.ts
+++ b/src/constants/input/input.ts
@@ -1,0 +1,12 @@
+export const INPUT_SIZES = {
+  sm: 'h-10 px-3',
+  md: 'h-11 px-4',
+  lg: 'h-12 px-5',
+} as const;
+
+export const INPUT_VARIANTS = {
+  default: 'border-gray-300  bg-white text-gray-900 focus:border-pink-400 ',
+  error: 'border-red-400 bg-white text-gray-900  ',
+  success: 'border-green-600 bg-white text-gray-900  ',
+  disabled: 'border-gray-200 bg-gray-50 text-gray-400 cursor-not-allowed',
+} as const;

--- a/src/constants/input/input.ts
+++ b/src/constants/input/input.ts
@@ -10,4 +10,3 @@ export const INPUT_VARIANTS = {
   success: 'border-green-600 bg-white text-gray-900',
   disabled: 'border-gray-200 bg-gray-50 text-gray-400 cursor-not-allowed',
 } as const;
-

--- a/src/constants/input/input.ts
+++ b/src/constants/input/input.ts
@@ -5,8 +5,9 @@ export const INPUT_SIZES = {
 } as const;
 
 export const INPUT_VARIANTS = {
-  default: 'border-gray-300  bg-white text-gray-900 focus:border-pink-400 ',
-  error: 'border-red-400 bg-white text-gray-900  ',
-  success: 'border-green-600 bg-white text-gray-900  ',
+  default: 'border-gray-300  bg-white text-gray-900 focus:border-pink-400',
+  error: 'border-red-400 bg-white text-gray-900',
+  success: 'border-green-600 bg-white text-gray-900',
   disabled: 'border-gray-200 bg-gray-50 text-gray-400 cursor-not-allowed',
 } as const;
+


### PR DESCRIPTION
## 🔗 관련 이슈

- #9 

## ✨ 작업 개요

- input 공통컴포넌트 생성 
- input 스타일 상수 

## ✅ 작업 상세 내용

- 공통 input 컴포넌트 추가 
  - src/components/common/Input.tsx : input 공통 컴포넌트
  - src/constants/input/input.ts : input 스타일 상수

- React hook form 사용을 고려해서 확장성 있게 코드를 구현함 



## 📎 참고 사항
- 추후 논의 : 인풋창 밑에 helpertext 가 존재하는 경우(유효성 검사 메시지)  -> 지금은 인풋창 움직임 / 추후에 따로 옵셔널로 뺄지 고민