### PR TITLE
feat: 모달 공통컴포넌트 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "postcss": "^8.5.6",
         "react": "19.1.0",
         "react-dom": "19.1.0",
-        "tailwind-merge": "^3.3.1"
+        "tailwind-merge": "^3.3.1",
+        "zustand": "^5.0.6"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -2731,7 +2732,7 @@
     },
     "node_modules/@types/react": {
       "version": "19.1.8",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.0.2"
@@ -3677,7 +3678,7 @@
     },
     "node_modules/csstype": {
       "version": "3.1.3",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
@@ -7521,6 +7522,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.6.tgz",
+      "integrity": "sha512-ihAqNeUVhe0MAD+X8M5UzqyZ9k3FFZLBTtqo6JLPwV53cbRB/mJwBI0PxcIgqhBBHlEs8G45OTDTMq3gNcLq3A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "postcss": "^8.5.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "zustand": "^5.0.6"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -24,6 +24,7 @@ export default function RootLayout({
       <body className={`antialiased`}>
         <Header />
         {children}
+        <div id="modal" />
         <Footer />
       </body>
     </html>

--- a/src/components/common/modal/ConfirmModal.tsx
+++ b/src/components/common/modal/ConfirmModal.tsx
@@ -1,0 +1,44 @@
+// components/modal/ConfirmModal.tsx
+import Button from '@/components/common/Button';
+import Modal from './Modal';
+
+interface ConfirmModalProps {
+  isOpen: boolean;
+  modalId: string;
+  title: string;
+  message: string;
+  onClose: () => void;
+  onConfirm: () => void;
+}
+
+const ConfirmModal = ({
+  isOpen,
+  modalId,
+  title,
+  message,
+  onClose,
+  onConfirm,
+}: ConfirmModalProps) => {
+  return (
+    <Modal
+      modalId={modalId}
+      isOpen={isOpen}
+      onClose={onClose}
+      hasCloseButton={false}
+      className="w-[280px] px-6 py-4 pt-8"
+    >
+      <div className="mb-4 text-center text-xl font-bold">{title}</div>
+      <p className="mb-6 text-center">{message}?</p>
+      <div className="flex justify-between border-t border-gray-200 pt-4">
+        <Button onClick={onClose} variant="transparent">
+          아니요
+        </Button>
+        <Button onClick={onConfirm} variant="transparent">
+          확인
+        </Button>
+      </div>
+    </Modal>
+  );
+};
+
+export default ConfirmModal;

--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -1,0 +1,101 @@
+import Portal from '@/components/common/modal/Portal';
+import { Z_INDEX } from '@/constants/zIndex';
+import { useEscapeKey } from '@/hooks/useEscapeKey';
+import useScrollLock from '@/hooks/useScrollLock';
+import { useModalStore } from '@/store/modalStore';
+import { cn } from '@/utils/cn';
+import { RiCloseLine } from '@remixicon/react';
+import { useEffect } from 'react';
+
+interface ModalProps {
+  modalId: string; // 모달 고유 id
+  isOpen: boolean; // 모달 열림 상태 제어
+  onClose: () => void; // 닫기 함수 전달
+  children: React.ReactNode;
+  className?: string;
+  hasCloseButton?: boolean; // 닫기 버튼 표시 여부
+  isBackgroundOverlay?: boolean; // 배경 오버레이 여부
+  zIndexBase?: number; // z-index 기준값
+}
+
+const Modal = ({
+  modalId,
+  isOpen,
+  onClose,
+  children,
+  className,
+  hasCloseButton = true,
+  isBackgroundOverlay = true,
+  zIndexBase = Z_INDEX.MODAL,
+}: ModalProps) => {
+  const { openModal, closeModal, openModals, getTopModal } = useModalStore();
+
+  // 모달 닫기 함수
+  const handleClose = () => {
+    onClose();
+    closeModal(modalId);
+  };
+
+  // 현재 모달이 최상단 모달인지 판단
+  const topModalId = getTopModal();
+  const isTopModal = topModalId === modalId;
+
+  // esc 키로 모달 닫기
+  useEscapeKey(() => {
+    if (isOpen && isTopModal) {
+      onClose();
+      closeModal(modalId);
+    }
+  });
+
+  // 스크롤 막기
+  useScrollLock(isOpen && isTopModal);
+
+  // 모달 열림 상태 관리
+  useEffect(() => {
+    if (isOpen) openModal(modalId);
+    else closeModal(modalId);
+
+    // 클린업시 모달닫기
+    return () => closeModal(modalId);
+  }, [isOpen, modalId, openModal, closeModal]);
+
+  // 현재 열린 모달이 없으면 렌더링 x
+  if (!openModals.includes(modalId)) return null;
+  
+  // z-index 계산 (열린 순서 기준)
+  const currentZIndex = zIndexBase + openModals.indexOf(modalId) * 10;
+
+  return (
+    <Portal targetId="modal">
+      <div
+        id={modalId}
+        className={cn(
+          'fixed inset-0 flex h-screen w-screen items-center justify-center',
+          isBackgroundOverlay && 'bg-black/30'
+        )}
+        style={{ zIndex: currentZIndex }}
+        onClick={isTopModal ? handleClose : undefined}
+      >
+        <div
+          className={cn(
+            'relative rounded-md bg-white px-6 py-8 shadow-lg transition-all',
+            className
+          )}
+          onClick={(e) => e.stopPropagation()}
+        >
+          {children}
+          {hasCloseButton && (
+            <button
+              onClick={handleClose}
+              className="absolute top-8 right-6 cursor-pointer"
+            >
+              <RiCloseLine />
+            </button>
+          )}
+        </div>
+      </div>
+    </Portal>
+  );
+};
+export default Modal;

--- a/src/components/common/modal/Modal.tsx
+++ b/src/components/common/modal/Modal.tsx
@@ -62,7 +62,7 @@ const Modal = ({
 
   // 현재 열린 모달이 없으면 렌더링 x
   if (!openModals.includes(modalId)) return null;
-  
+
   // z-index 계산 (열린 순서 기준)
   const currentZIndex = zIndexBase + openModals.indexOf(modalId) * 10;
 
@@ -71,11 +71,14 @@ const Modal = ({
       <div
         id={modalId}
         className={cn(
-          'fixed inset-0 flex h-screen w-screen items-center justify-center',
+          'fixed inset-0 flex items-center justify-center',
           isBackgroundOverlay && 'bg-black/30'
         )}
         style={{ zIndex: currentZIndex }}
         onClick={isTopModal ? handleClose : undefined}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={`${modalId}`}
       >
         <div
           className={cn(
@@ -89,6 +92,7 @@ const Modal = ({
             <button
               onClick={handleClose}
               className="absolute top-8 right-6 cursor-pointer"
+              aria-label="모달 닫기"
             >
               <RiCloseLine />
             </button>

--- a/src/components/common/modal/Portal.tsx
+++ b/src/components/common/modal/Portal.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+interface PortalProps {
+  children: React.ReactNode;
+  targetId?: string; // 렌더링할 DOM 노드 아이디
+}
+
+// Portal로 감싼 내용을 다른 DOM 위치에 렌더링해주는 컴포넌트
+export default function Portal({ children, targetId = 'modal' }: PortalProps) {
+  const [mounted, setMounted] = useState(false); // 클라이언트 마운트 여부
+
+  // 컴포넌트가 마운트된 후에만 Portal을 렌더링
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  // 서버 사이드 렌더링 시 포탈을 렌더링하지 않음
+  if (!mounted) return null;
+
+  // targetId를 가진 자식 요소를 포탈로 렌더링
+  const el = document.getElementById(targetId);
+  return el ? createPortal(children, el) : null;
+}

--- a/src/components/layout/Header/CategoryMenu.tsx
+++ b/src/components/layout/Header/CategoryMenu.tsx
@@ -1,15 +1,10 @@
+import { CATEGORY_MENU_ITEMS } from '@/constants/category/menuItems';
 import Link from 'next/link';
-
-const menuItems = [
-  { label: '오늘 뭐하지', href: '/today' },
-  { label: '보드큐 추천', href: '/recommend' },
-  { label: '보드게임 찾기', href: '/search' },
-];
 
 export default function CategoryMenu() {
   return (
     <nav className="hidden gap-6 text-sm font-semibold lg:flex">
-      {menuItems.map((item, i) => (
+      {CATEGORY_MENU_ITEMS.map((item, i) => (
         <Link key={i} href={item.href}>
           {item.label}
         </Link>

--- a/src/components/layout/Header/MobileMenu.tsx
+++ b/src/components/layout/Header/MobileMenu.tsx
@@ -2,7 +2,9 @@
 
 import Button from '@/components/common/Button';
 import { CATEGORY_MENU_ITEMS } from '@/constants/category/menuItems';
+import { Z_INDEX } from '@/constants/zIndex';
 import { useEscapeKey } from '@/hooks/useEscapeKey';
+import useScrollLock from '@/hooks/useScrollLock';
 import { cn } from '@/utils/cn';
 import {
   RiArrowRightSLine,
@@ -11,7 +13,7 @@ import {
   RiUserLine,
 } from '@remixicon/react';
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 export default function MobileMenu() {
   // 메뉴바 상태
@@ -22,12 +24,7 @@ export default function MobileMenu() {
   useEscapeKey(handleClose);
 
   // 스크롤 막기
-  useEffect(() => {
-    document.body.style.overflow = isOpen ? 'hidden' : '';
-    return () => {
-      document.body.style.overflow = '';
-    };
-  }, [isOpen]);
+  useScrollLock(isOpen);
 
   return (
     <>
@@ -40,17 +37,19 @@ export default function MobileMenu() {
       {/* 오버레이 */}
       {isOpen && (
         <div
-          className="fixed inset-0 z-40 bg-black/50 lg:hidden"
+          className="fixed inset-0 bg-black/50 lg:hidden"
+          style={{ zIndex: Z_INDEX.MOBILE_MENU }}
           onClick={handleClose}
         />
       )}
       {/* 슬라이드 메뉴 */}
       <aside
         className={cn(
-          `fixed top-0 right-0 z-50 h-full w-64 transform bg-white font-medium shadow transition-transform duration-300 lg:hidden ${
+          `fixed top-0 right-0 h-full w-64 transform bg-white font-medium shadow transition-transform duration-300 lg:hidden ${
             isOpen ? 'translate-x-0' : 'translate-x-full'
           }`
         )}
+        style={{ zIndex: Z_INDEX.MOBILE_MENU + 1 }}
       >
         <div className="flex h-full flex-col gap-4 p-6">
           <div className="mb-2 flex items-center justify-between">

--- a/src/components/layout/Header/MobileMenu.tsx
+++ b/src/components/layout/Header/MobileMenu.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Button from '@/components/common/Button';
+import { CATEGORY_MENU_ITEMS } from '@/constants/category/menuItems';
 import { useEscapeKey } from '@/hooks/useEscapeKey';
 import { cn } from '@/utils/cn';
 import {
@@ -11,17 +12,6 @@ import {
 } from '@remixicon/react';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
-
-interface MenuItem {
-  label: string;
-  href: string;
-}
-
-const menuItems: MenuItem[] = [
-  { label: '보드큐 소개', href: '/introduce' },
-  { label: '오늘 뭐하지', href: '/recommend' },
-  { label: '보드게임 찾기', href: '/search' },
-];
 
 export default function MobileMenu() {
   // 메뉴바 상태
@@ -87,7 +77,7 @@ export default function MobileMenu() {
           <div className="my-1 border border-gray-200"></div>
 
           {/* 메뉴 항목들 */}
-          {menuItems.map(({ label, href }, index) => (
+          {CATEGORY_MENU_ITEMS.map(({ label, href }, index) => (
             <div key={index}>
               <Link href={href} onClick={handleClose}>
                 {label}

--- a/src/constants/category/menuItems.ts
+++ b/src/constants/category/menuItems.ts
@@ -1,0 +1,5 @@
+export const CATEGORY_MENU_ITEMS = [
+  { label: '보드Pick!', href: '/today' },
+  { label: '보드큐 추천', href: '/recommend' },
+  { label: '보드게임 찾기', href: '/search' },
+];

--- a/src/constants/category/menuItems.tsx
+++ b/src/constants/category/menuItems.tsx
@@ -2,7 +2,7 @@ export const CATEGORY_MENU_ITEMS = [
   {
     label: (
       <>
-        보드<span className="text-primary-500">Pick!</span>
+        보드<span className="text-primary-500 font-bold">Pick!</span>
       </>
     ),
     href: '/today',

--- a/src/constants/category/menuItems.tsx
+++ b/src/constants/category/menuItems.tsx
@@ -1,5 +1,12 @@
 export const CATEGORY_MENU_ITEMS = [
-  { label: '보드Pick!', href: '/today' },
+  {
+    label: (
+      <>
+        보드<span className="text-primary-500">Pick!</span>
+      </>
+    ),
+    href: '/today',
+  },
   { label: '보드큐 추천', href: '/recommend' },
   { label: '보드게임 찾기', href: '/search' },
 ];

--- a/src/constants/zIndex.ts
+++ b/src/constants/zIndex.ts
@@ -1,0 +1,7 @@
+export const Z_INDEX = {
+  HEADER: 50,
+  DROPDOWN: 100,
+  MODAL: 200,
+  TOAST: 300,
+  MOBILE_MENU: 900,
+} as const;

--- a/src/hooks/useScrollLock.ts
+++ b/src/hooks/useScrollLock.ts
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+
+const useScrollLock = (shouldLock: boolean) => {
+  useEffect(() => {
+    document.body.style.overflow = shouldLock ? 'hidden' : '';
+    return () => {
+      document.body.style.overflow = '';
+    };
+  }, [shouldLock]);
+};
+
+export default useScrollLock;

--- a/src/store/modalStore.ts
+++ b/src/store/modalStore.ts
@@ -1,0 +1,31 @@
+import { create } from 'zustand';
+
+// 모달 상태 타입 정의
+interface ModalState {
+  openModals: string[];
+  openModal: (id: string) => void;
+  closeModal: (id: string) => void;
+  getTopModal: () => string | null;
+}
+
+// zustand 스토어 생성
+export const useModalStore = create<ModalState>((set, get) => ({
+  openModals: [],
+  // 모달 열기
+  openModal: (id) =>
+    set((state) => ({
+      // 모달이 이미 열려있다면 중복 제거 후 맨 뒤로 추가
+      openModals: [...state.openModals.filter((mid) => mid !== id), id],
+    })),
+  // 모달 닫기
+  closeModal: (id) =>
+    set((state) => ({
+      // 해당 id를 가진 모달만 제거
+      openModals: state.openModals.filter((mid) => mid !== id),
+    })),
+  // 최상단 모달 가져오기
+  getTopModal: () => {
+    const { openModals } = get();
+    return openModals[openModals.length - 1] || null;
+  },
+}));

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,5 +1,0 @@
-import type { Config } from 'tailwindcss';
-
-const config: Config = {};
-
-export default config;


### PR DESCRIPTION
## 🔗 관련 이슈

- #14 

## ✨ 작업 개요

- 모달 공통 컴포넌트 추가
- 헤더 메뉴 상수 분리

## ✅ 작업 상세 내용

- 모달 공통 컴포넌트 구현
  -  zustand 라이브러리 추가
  -  layout.tsx : `<div id="modal" />` 추가 (Portal 대상 노드 용도)
  - components/common/modal/Modal.tsx : 모달 공통 컴포넌트
  - components/common/modal/confirmModal.tsx : 임시로 만든 확인용 모달 컴포넌트
  - components/common/modal/Portal.tsx : 클라이언트 사이드에서 모달 포탈을 위한 Portal 컴포넌트
  - store/modalStore.ts : zustand 기반 모달 상태 전역 관리 스토어 
- 스크롤 방지 훅 추가 (useScrollLock.ts)
-  z-index 상수 정의(zIndex.ts)
- 헤더 메뉴 항목 상수 분리
  - menuItems.tsx : 메뉴 항목 상수 정의
  - CategoryMenu.tsx : 기존 const menuItems를 삭제 후 menuItems.tsx를 import해와 사용하는 것으로 변경
  - MobileMenu.tsx : CategoryMenu.tsx와 동일
- 린트 설정이 추가됨에 따라 tailwind.config.ts 제거

## 📎 참고 사항
- 새 라이브러리 zustand가 추가되었으니 **npm i** 부탁드립니다.

## 사용법

모달 상태
```typescript
// 모달 상태
const [isOpen, setIsOpen] = useState(false);
// 중첩 모달 상태
const [isConfirmOpen, setIsConfirmOpen] = useState(false);
// 확인 시 알림 함수
const handleConfirm = () => {
  alert('확인 눌렀음');
  setIsConfirmOpen(false);
};
return (
  <div>
    <button onClick={() => setIsOpen(true)}>Open Modal</button>
    <Modal
      modalId="myModal"
      isOpen={isOpen}
      onClose={() => setIsOpen(false)}
      className="w-[480px]"
    >
      <div className="text-lg font-bold">커스텀 모달</div>
      <p className="mt-4 text-sm text-gray-500">
        여기에 원하는 내용을 넣으세요. 
      </p>
      <button
        className="mt-8 rounded bg-black px-4 py-2 text-white"
        onClick={() => setIsConfirmOpen(true)}
      >
        삭제하기
      </button>
    </Modal>
    <ConfirmModal
      isOpen={isConfirmOpen}
      modalId="confirmModal"
      title="리뷰 삭제"
      message="정말 삭제하시겠습니까?"
      onClose={() => setIsConfirmOpen(false)}
      onConfirm={handleConfirm}
    />
    메인페이지
  </div>
  );
```

## 스크린샷

<img width="589" height="551" alt="스크린샷 2025-07-30 오전 2 06 58" src="https://github.com/user-attachments/assets/3de8f4b3-29a1-4897-8437-03fb16ecea45" />
