### PR TITLE
feat: Dropdown 컴포넌트 구현 (#38)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,6 +1,7 @@
 @import 'tailwindcss';
 
 @theme {
+  --color-black: #17171b;
   --color-success-50: #f6fef9;
   --color-success-100: #effdf6;
   --color-success-200: #d9f9e6;

--- a/src/components/common/Dropdown.tsx
+++ b/src/components/common/Dropdown.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useEscapeKey } from '@/hooks/useEscapeKey';
+import { useOutsideClick } from '@/hooks/useOutsideClick';
+import { cn } from '@/utils/cn'; // className join 유틸 (선택)
+import { RiArrowDownSLine } from '@remixicon/react';
+import { useRef, useState } from 'react';
+
+interface Option {
+  label: string;
+  value: string;
+}
+
+interface DropdownProps {
+  options: Option[];
+  selectedValue: string;
+  onChange: (value: string) => void;
+}
+
+export default function Dropdown({
+  options,
+  selectedValue,
+  onChange,
+}: DropdownProps) {
+  const [isOpen, setIsOpen] = useState(true);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const selectedLabel =
+    options.find((opt) => opt.value === selectedValue)?.label ?? '';
+
+  // 외부 클릭 시 닫기
+  useOutsideClick(dropdownRef, () => setIsOpen(false));
+  useEscapeKey(() => setIsOpen(false));
+
+  return (
+    <div className="relative inline-block text-left" ref={dropdownRef}>
+      <button
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+        onClick={() => setIsOpen((prev) => !prev)}
+        id="dropdown-button"
+        className="flex items-center gap-1 text-base font-medium text-black"
+      >
+        {selectedLabel}
+        <RiArrowDownSLine className="h-4 w-4" />
+      </button>
+
+      {isOpen && (
+        <div className="absolute right-0 z-50 mt-3 w-40 overflow-hidden rounded-2xl bg-white px-4 py-6 shadow-lg ring-1 ring-black/5">
+          <ul
+            role="listbox"
+            aria-labelledby="dropdown-button"
+            className="space-y-2"
+          >
+            {options.map((option) => {
+              const isSelected = selectedValue === option.value;
+              return (
+                <li
+                  key={option.value}
+                  role="option"
+                  aria-selected={isSelected}
+                  onClick={() => {
+                    onChange(option.value);
+                    setIsOpen(false);
+                  }}
+                  className={cn(
+                    'relative flex cursor-pointer items-center justify-between rounded-lg px-4 py-2 text-sm hover:bg-gray-50',
+                    isSelected &&
+                      'before:bg-primary-400 bg-gray-100 font-semibold before:absolute before:top-0 before:-left-4 before:h-full before:w-2 before:rounded-lg before:content-[""]'
+                  )}
+                >
+                  <span>{option.label}</span>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/hooks/useOutsideClick.ts
+++ b/src/hooks/useOutsideClick.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+
+export function useOutsideClick(
+  ref: React.RefObject<HTMLElement | null>,
+  onOutsideClick: () => void
+) {
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onOutsideClick();
+      }
+    };
+    document.addEventListener('pointerdown', handleClick);
+    return () => {
+      document.removeEventListener('pointerdown', handleClick);
+    };
+  }, [onOutsideClick]);
+}


### PR DESCRIPTION
## 📌 관련 이슈
* 관련 이슈: #38 

## ✅ 변경 사항
* **Dropdown 컴포넌트 구현**
  * 옵션 배열을 받아 선택된 항목 표시 및 변경 이벤트 핸들링
  * 접근성 고려: `aria-haspopup`, `aria-expanded`, `aria-selected`, `role="listbox"` 등 추가
  * 선택된 항목 강조 스타일링 (좌측 인디케이터 및 배경색)

* **useOutsideClick 훅 구현**
  * `ref` 요소 외부 클릭 시 콜백 실행
  * `pointerdown` 이벤트 기반으로 구현하여 마우스 및 터치 대응
  * Dropdown 닫힘 처리 등에 활용

* **Tailwind `black` 컬러 재정의**
  * 기존 `black` 색상을 디자인 요구사항에 맞게 커스터마이징
  * 색상 일관성을 위해 Tailwind 설정파일 내 theme 확장 적용

## 📸 UI 스크린샷
<img width="199" height="249" alt="스크린샷 2025-07-30 오후 5 02 28" src="https://github.com/user-attachments/assets/316ad03c-fbc5-436f-a6a0-1e82a79d5f52" />


## 사용법(예시)
```jsx
        <RangeSlider
          min={0}
          max={120}
          value={playTime}
          unit="분"
          onChange={setPlayTime}
        />
```
