### PR TITLE
feat: react hook form 구현 (#57)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "postcss": "^8.5.6",
         "react": "19.1.0",
         "react-dom": "19.1.0",
+        "react-hook-form": "^7.62.0",
         "tailwind-merge": "^3.3.1",
         "zustand": "^5.0.6"
       },
@@ -6407,6 +6408,22 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.62.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
+      "integrity": "sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "postcss": "^8.5.6",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "react-hook-form": "^7.62.0",
     "tailwind-merge": "^3.3.1",
     "zustand": "^5.0.6"
   },

--- a/src/hooks/useEmailValidation.ts
+++ b/src/hooks/useEmailValidation.ts
@@ -1,0 +1,13 @@
+export function useEmailValidation() {
+  const emailRules = {
+    required: '이메일을 입력해주세요',
+    pattern: {
+      value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+      message: '올바른 이메일 형식을 입력해주세요',
+    },
+  };
+
+  return {
+    emailRules,
+  };
+}

--- a/src/hooks/useNicknameValidation.ts
+++ b/src/hooks/useNicknameValidation.ts
@@ -1,0 +1,17 @@
+export function useNicknameValidation() {
+  const nicknameRules = {
+    required: '닉네임을 입력해주세요',
+    minLength: {
+      value: 2,
+      message: '닉네임은 2글자 이상 입력해주세요',
+    },
+    maxLength: {
+      value: 20,
+      message: '닉네임은 20글자 이하로 입력해주세요',
+    },
+  };
+
+  return {
+    nicknameRules,
+  };
+}

--- a/src/hooks/usePasswordValidation.ts
+++ b/src/hooks/usePasswordValidation.ts
@@ -1,0 +1,20 @@
+export function usePasswordValidation() {
+  const passwordRules = {
+    required: '비밀번호를 입력해주세요',
+    minLength: {
+      value: 8,
+      message: '비밀번호는 8자리 이상 입력해주세요',
+    },
+  };
+
+  const confirmPasswordRules = (password: string) => ({
+    required: '비밀번호 확인을 입력해주세요',
+    validate: (value: string) =>
+      value === password || '비밀번호가 일치하지 않습니다',
+  });
+
+  return {
+    passwordRules,
+    confirmPasswordRules,
+  };
+}

--- a/src/hooks/usePhoneValidation.ts
+++ b/src/hooks/usePhoneValidation.ts
@@ -1,0 +1,24 @@
+export function usePhoneValidation() {
+  const phoneRules = {
+    required: '휴대폰 번호를 입력해주세요',
+    pattern: {
+      value: /^010[0-9]{8}$/,
+      message: '010으로 시작하는 11자리 숫자를 입력해주세요',
+    },
+  };
+
+  const convertToInternational = (phone: string) => {
+    const cleaned = phone.replace(/[^0-9]/g, '');
+
+    if (cleaned.startsWith('010') && cleaned.length === 11) {
+      return `+82${cleaned.substring(1)}`;
+    }
+
+    return phone;
+  };
+
+  return {
+    phoneRules,
+    convertToInternational,
+  };
+}


### PR DESCRIPTION
# 🔗 관련 이슈

- Closes #57 

## ✨ 작업 개요

React Hook Form과 함께 사용할 수 있는 재사용 가능한 유효성 검사 훅들을 구현

## ✅ 작업 상세 내용

-  src/hooks/useEmailValidation: 이메일 형식 유효성 검사 훅
- src/hooks/useNicknameValidation: 닉네임 길이(2-20자) 유효성 검사 훅  
- src/hooks/usePasswordValidation: 비밀번호 길이(8자 이상) + 확인 유효성 검사 훅
- src/hooks/usePhoneValidation: 휴대폰 번호(010 + 11자리) + 국제형식 변환 훅 
-
## 📎 참고 사항

```
import { useForm } from 'react-hook-form';
import { useEmailValidation } from '@/hooks/useEmailValidation';
import Input from '@/components/common/Input';

function LoginPage() {
  const { register, formState: { errors } } = useForm();
  const { emailRules } = useEmailValidation();

  return (
    <Input
      placeholder="이메일 입력"
      error={errors.email?.message}
      {...register('email', emailRules)}
    />
  );
}
```

** npm i ** 해주세요