### PR TITLE
refactor: GameItem 컴포넌트 수정(#62)

### DIFF
--- a/src/components/game/GameItem.tsx
+++ b/src/components/game/GameItem.tsx
@@ -47,7 +47,10 @@ export default function GameItem({
   return (
     <Link
       href={`/games/${game_id}`}
-      className={cn('group flex flex-col gap-2', className)}
+      className={cn(
+        'group relative flex flex-col gap-4 overflow-hidden rounded-xl',
+        className
+      )}
     >
       <div
         className={cn(
@@ -64,35 +67,71 @@ export default function GameItem({
         />
 
         {overlayInfo && (
-          <div className="absolute inset-0 flex flex-col justify-end bg-black/50 p-2 text-white">
+          <div className="">
             <h3 className="truncate text-sm font-semibold">{title}</h3>
           </div>
         )}
 
-        {showLikeButton && <LikeButton liked={is_liked} gameId={game_id} />}
+        {showLikeButton && (
+          <LikeButton
+            liked={is_liked}
+            gameId={game_id}
+            className={cn(
+              'absolute right-2 z-10',
+              overlayInfo ? 'top-2' : 'bottom-2'
+            )}
+          />
+        )}
       </div>
 
-      <h3 className="truncate text-sm font-medium">{title}</h3>
-      <div className="flex items-center gap-6 text-sm text-gray-500">
-        <div className="flex items-center gap-2">
-          <RiHeartFill className="h-4 w-4 text-gray-300" />
-          <span className="text-xs">{like_count ?? 0}</span>
-        </div>
-        <div className="flex items-center gap-2">
-          <RiStarFill className="h-4 w-4 text-gray-300" />
-          <span className="text-xs">{average_rating?.toFixed(1) ?? '-'}</span>
-        </div>
-      </div>
-
-      <div className="mt-1 flex flex-wrap gap-1">
-        {tags.map((tag, idx) => (
-          <span
-            key={idx}
-            className="bg-primary-50 text-primary-500 rounded-full px-2 py-1 text-[10px] font-medium"
+      <div
+        className={
+          overlayInfo
+            ? 'absolute inset-0 flex flex-col justify-end bg-gradient-to-t from-black/50 to-transparent p-4 text-white'
+            : ''
+        }
+      >
+        <h3 className="mb-2.5 truncate text-base font-semibold">{title}</h3>
+        {(like_count || average_rating) && (
+          <div
+            className={cn(
+              'mb-2 flex items-center gap-6 text-sm',
+              overlayInfo ? 'text-white' : 'text-gray-500'
+            )}
           >
-            #{tag}
-          </span>
-        ))}
+            {like_count && (
+              <div className="flex items-center gap-2">
+                <RiHeartFill className="h-4 w-4 text-gray-300" />
+                <span className="text-xs">{like_count ?? 0}</span>
+              </div>
+            )}
+            {average_rating && (
+              <div className="flex items-center gap-2">
+                <RiStarFill className="h-4 w-4 text-gray-300" />
+                <span className="text-xs">
+                  {average_rating?.toFixed(1) ?? '-'}
+                </span>
+              </div>
+            )}
+          </div>
+        )}
+        {tags.length > 0 && (
+          <div className="mt-1 flex flex-wrap gap-1">
+            {tags.map((tag, idx) => (
+              <span
+                key={idx}
+                className={cn(
+                  'rounded-full px-2 py-1 text-[10px] font-medium',
+                  overlayInfo
+                    ? 'bg-primary-500 text-white'
+                    : 'bg-primary-50 text-primary-500'
+                )}
+              >
+                #{tag}
+              </span>
+            ))}
+          </div>
+        )}
       </div>
     </Link>
   );

--- a/src/components/game/GameList.tsx
+++ b/src/components/game/GameList.tsx
@@ -6,12 +6,17 @@ interface GameListProps {
   games: GameListData[];
   columnNumber?: number;
   imageRatio?: '1:1' | '4:5' | '2:3';
+  overlayInfo?: boolean;
+  showLikeButton?: boolean;
+  className?: string;
 }
 
 export default function GameList({
   games,
   columnNumber = 3,
   imageRatio = '4:5',
+  overlayInfo,
+  showLikeButton,
 }: GameListProps) {
   return (
     <div
@@ -24,7 +29,13 @@ export default function GameList({
       )}
     >
       {games.map((game) => (
-        <GameItem key={game.game_id} game={game} imageRatio={imageRatio} />
+        <GameItem
+          key={game.game_id}
+          game={game}
+          overlayInfo={overlayInfo}
+          imageRatio={imageRatio}
+          showLikeButton={showLikeButton}
+        />
       ))}
     </div>
   );

--- a/src/components/game/LikeButton.tsx
+++ b/src/components/game/LikeButton.tsx
@@ -1,15 +1,18 @@
 'use client';
+import { cn } from '@/utils/cn';
 import { RiHeartFill, RiHeartLine } from '@remixicon/react';
 import { useState } from 'react';
 
 interface LikeButtonProps {
   liked: boolean;
   gameId: number;
+  className?: string;
 }
 
 export default function LikeButton({
   liked = false,
   gameId: _gameId,
+  className,
 }: LikeButtonProps) {
   const [isLiked, setIsLiked] = useState(liked);
   const handleLikeClick = (e: React.MouseEvent) => {
@@ -21,7 +24,7 @@ export default function LikeButton({
   return (
     <button
       onClick={handleLikeClick}
-      className="absolute right-0 bottom-0 z-10 cursor-pointer p-2"
+      className={cn('z-10 cursor-pointer p-2', className)}
     >
       {isLiked ? (
         <RiHeartFill className="text-primary-400 h-6 w-6" />


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #62 

## ✨ 작업 개요

GameItem UI를 `overlayInfo` 옵션 기반으로 오버레이 방식으로 표현할 수 있도록 리팩토링하고, GameList에서 해당 기능을 사용할 수 있도록 props를 확장합니다.

## ✅ 작업 상세 내용

### GameItem.tsx
- 카드 UI를 개별 페이지 요구사항에 따라 따로 만들지 않고,  **prop 기반 옵션화**로 설계
  →  여러 페이지에서 동일 컴포넌트를 유연하게 활용 가능
  - `overlayInfo` prop 추가: true일 경우 이미지 위 오버레이 형태로 카드 정보 표시
  - `showLikeButton` prop에 따라 좋아요 버튼 표시 여부 제어
- `title`, `like_count`, `average_rating`, `tags`를 오버레이 레이아웃에 맞게 재구성
- `LikeButton` 위치를 overlay 여부에 따라 top/bottom으로 동적 조절
- 전체 카드에 `overflow-hidden`, `rounded-xl` 추가로 비주얼 통일성 확보

### GameList.tsx
- `overlayInfo`, `showLikeButton`, `className` prop 추가
- `GameItem`에 props 전달되도록 map 내부 로직 수정
- 외부에서 카드 스타일 및 표시 방식 제어 가능

## 📎 참고 사항

- GameList의 유연한 재사용을 위해 className 전달 허용
- 디자인 시안에 따라 LikeButton 위치가 위 또는 아래로 바뀔 수 있도록 유연성 확보
- 태그 색상 및 위치도 overlay 여부에 따라 조절 가능
- 추후 `hover` 기반 오버레이 전환 효과 추가 가능성 있음

## 🖼 스크린샷
<img width="875" height="521" alt="image" src="https://github.com/user-attachments/assets/6012d546-f18f-47a0-98b3-d2679d72c335" />

<img width="1090" height="667" alt="스크린샷 2025-08-05 오전 3 18 38" src="https://github.com/user-attachments/assets/6f4e486e-a8c4-4f8a-bdc8-7015d743797b" />

4:5 비율, overlayInfo true 일때 
