### PR TITLE
feat: React Query 전역 상태 관리 및 공통 fetcher 유틸 추가 (#78)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,8 @@
       "dependencies": {
         "@remixicon/react": "^4.6.0",
         "@svgr/webpack": "^8.1.0",
+        "@tanstack/react-query": "^5.85.0",
+        "@tanstack/react-query-devtools": "^5.85.0",
         "axios": "^1.11.0",
         "clsx": "^2.1.1",
         "next": "15.4.2",
@@ -2699,6 +2701,59 @@
         "@tailwindcss/oxide": "4.1.11",
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.11"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.83.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.83.1.tgz",
+      "integrity": "sha512-OG69LQgT7jSp+5pPuCfzltq/+7l2xoweggjme9vlbCPa/d7D7zaqv5vN/S82SzSYZ4EDLTxNO1PWrv49RAS64Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.84.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.84.0.tgz",
+      "integrity": "sha512-fbF3n+z1rqhvd9EoGp5knHkv3p5B2Zml1yNRjh7sNXklngYI5RVIWUrUjZ1RIcEoscarUb0+bOvIs5x9dwzOXQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.85.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.85.0.tgz",
+      "integrity": "sha512-t1HMfToVMGfwEJRya6GG7gbK0luZJd+9IySFNePL1BforU1F3LqQ3tBC2Rpvr88bOrlU6PXyMLgJD0Yzn4ztUw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.83.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.85.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.85.0.tgz",
+      "integrity": "sha512-Q/lmGAY2I3KkhxSJKLKQUeUBOc9Mv/OrCTw4CfUCq2Za+XhDsB5ZfVTOANAJyDZ+SiUu27Cw1eHNE+xJdACJiw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.84.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.85.0",
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@trysound/sax": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,8 @@
   "dependencies": {
     "@remixicon/react": "^4.6.0",
     "@svgr/webpack": "^8.1.0",
+    "@tanstack/react-query": "^5.85.0",
+    "@tanstack/react-query-devtools": "^5.85.0",
     "axios": "^1.11.0",
     "clsx": "^2.1.1",
     "next": "15.4.2",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import Footer from '@/components/layout/Footer';
 import Header from '@/components/layout/Header/Header';
 import type { Metadata } from 'next';
 import './globals.css';
-import Providers from './provider';
+import Providers from './providers';
 
 export const metadata: Metadata = {
   title: '보드큐',

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import Footer from '@/components/layout/Footer';
 import Header from '@/components/layout/Header/Header';
 import type { Metadata } from 'next';
 import './globals.css';
+import Providers from './provider';
 
 export const metadata: Metadata = {
   title: '보드큐',
@@ -22,10 +23,12 @@ export default function RootLayout({
         href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css"
       />
       <body className={`flex min-h-screen flex-col antialiased`}>
-        <Header />
-        {children}
-        <Footer />
-        <div id="modal" />
+        <Providers>
+          <Header />
+          {children}
+          <Footer />
+          <div id="modal" />
+        </Providers>
       </body>
     </html>
   );

--- a/src/app/provider.tsx
+++ b/src/app/provider.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
+import React, { useState } from 'react';
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient());
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  );
+}

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,11 +1,12 @@
 'use client';
 
+import queryClientOptions from '@/constants/api/queryClientOptions';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import React, { useState } from 'react';
 
 export default function Providers({ children }: { children: React.ReactNode }) {
-  const [queryClient] = useState(() => new QueryClient());
+  const [queryClient] = useState(() => new QueryClient(queryClientOptions));
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/src/constants/api/queryClientOptions.ts
+++ b/src/constants/api/queryClientOptions.ts
@@ -1,0 +1,18 @@
+import { defaultShouldDehydrateQuery, Query } from '@tanstack/react-query';
+
+const queryClientOptions = {
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60 * 5,
+      retry: 1,
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+    },
+    dehydrate: {
+      shouldDehydrateQuery: (query: Query) =>
+        defaultShouldDehydrateQuery(query) || query.state.status === 'pending',
+    },
+  },
+};
+
+export default queryClientOptions;

--- a/src/lib/fetcher.ts
+++ b/src/lib/fetcher.ts
@@ -1,0 +1,39 @@
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+class ApiError extends Error {
+  status: number;
+  info: unknown;
+
+  constructor(message: string, status: number, info: unknown) {
+    super(message);
+    this.status = status;
+    this.info = info;
+  }
+}
+
+export async function fetcher<T>(
+  endpoint: string,
+  options?: RequestInit,
+  accessToken?: string // SSR일 경우 직접 전달
+): Promise<T> {
+  const res = await fetch(`${API_BASE_URL}${endpoint}`, {
+    ...options,
+    headers: {
+      ...(options?.method !== 'GET' && { 'Content-Type': 'application/json' }),
+      ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
+      ...options?.headers,
+    },
+  });
+
+  if (!res.ok) {
+    const errorInfo = await res
+      .json()
+      .catch(() => ({ message: res.statusText }));
+    throw new ApiError(
+      errorInfo.message || res.statusText,
+      res.status,
+      errorInfo
+    );
+  }
+  return res.json();
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #78

## ✨ 작업 개요
* React Query 전역 상태 관리를 위한 환경 구성
* 공통 fetcher 유틸리티 함수 작성 및 인증/에러 처리 로직 반영
* 클라이언트/서버 모두에서 사용할 수 있는 안정적인 API 호출 구조 확보

## ✅ 작업 상세 내용
### 1. `Providers` 컴포넌트 추가 및 `layout.tsx` 적용

* `@tanstack/react-query` 설치 및 초기 세팅 완료
* `QueryClientProvider`, `ReactQueryDevtools` 포함된 `Providers` 컴포넌트 작성 (`use client`)
* `layout.tsx`에서 `Providers`로 전체 앱 감싸기 적용

### 2. 공통 fetcher 유틸 생성 및 구조화

* `fetcher<T>()` 함수 작성

  * `API_BASE_URL` 환경변수 기반으로 endpoint 구성
  * `accessToken` 존재 시 자동 Authorization 헤더 삽입
  * `POST`, `PUT` 요청 시에만 `Content-Type` 설정
  * 응답 실패 시 `ApiError` 클래스를 통해 상태코드 및 메시지 전달
  * 사용자 정의 headers 병합 처리

## 스크린샷
## 기타
* 후속 작업으로 fetcher를 사용하는 `queryFn` 모듈화 및 `useQuery` 적용 예정
* 추후 서버 전용 API 경로 분리 시, 서버 전용 환경변수(`INTERNAL_API_URL`) 도입 고려

