### PR TITLE
feat: 컴포넌트 세부 수정(#74)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -139,5 +139,10 @@ body {
 
 .theme-button-next,
 .theme-button-prev {
-  @apply hover:bg-primary-500 border-primary-400 text-primary-500 flex h-10 w-10 cursor-pointer items-center justify-center rounded-full border transition-colors hover:text-white;
+  @apply hover:bg-primary-500 border-primary-400 text-primary-500 pointer-events-auto flex h-10 w-10 cursor-pointer items-center justify-center rounded-full border transition-colors hover:text-white;
+}
+
+.main-button-next,
+.main-button-prev {
+  @apply hover:bg-primary-500 text-primary-500 pointer-events-auto flex h-12 w-12 cursor-pointer items-center justify-center rounded-full transition-colors hover:text-white;
 }

--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -86,7 +86,7 @@ export default function BoardPickPage() {
 
 function GradientLayout({ children }: { children: React.ReactNode }) {
   return (
-    <div className="min-h-[100dvh] bg-[linear-gradient(to_bottom,_#5a5a5a,_#17171B)] text-white">
+    <div className="relative min-h-[100dvh] bg-[linear-gradient(to_bottom,_#5a5a5a,_#17171B)] text-white">
       {children}
     </div>
   );

--- a/src/components/board-pick/IntroSection.tsx
+++ b/src/components/board-pick/IntroSection.tsx
@@ -5,7 +5,7 @@ import { RiArrowRightLine } from '@remixicon/react';
 
 export default function IntroSection({ onStart }: { onStart: () => void }) {
   return (
-    <div className="flex h-full flex-col items-center justify-center px-6">
+    <div className="absolute inset-0 flex h-full flex-col items-center justify-center px-6">
       <h1 className="mb-4 text-4xl font-bold">오늘의 게임은?</h1>
       <p className="mb-10 text-sm">
         상황에 맞게 오늘 플레이할 게임을 딱 정해드릴게요!

--- a/src/components/common/Checkbox.tsx
+++ b/src/components/common/Checkbox.tsx
@@ -15,8 +15,8 @@ const Checkbox = ({ onToggle, children, ...props }: CheckboxProps) => {
         onChange={onToggle}
         {...props}
       />
-      <span className="peer-checked:bg-primary-400 peer-checked:border-primary-400 flex h-5 w-5 items-center justify-center rounded border border-gray-400 transition-colors">
-        <RiCheckLine className="text-white" />
+      <span className="peer-checked:bg-primary-400 peer-checked:border-primary-400 flex h-5 w-5 items-center justify-center rounded border border-gray-400 text-transparent transition-colors peer-checked:text-white">
+        <RiCheckLine />
       </span>
       {children}
     </label>

--- a/src/components/common/Radio.tsx
+++ b/src/components/common/Radio.tsx
@@ -1,4 +1,3 @@
-import { RiCheckLine } from '@remixicon/react';
 import { InputHTMLAttributes } from 'react';
 
 interface RadioProps extends InputHTMLAttributes<HTMLInputElement> {
@@ -15,9 +14,7 @@ const Radio = ({ onToggle, children, ...props }: RadioProps) => {
         onChange={onToggle}
         {...props}
       />
-      <span className="peer-checked:border-primary-400 flex h-5 w-5 items-center justify-center rounded-full border border-gray-400 transition-all peer-checked:border-6">
-        <RiCheckLine className="text-white" />
-      </span>
+      <span className="peer-checked:border-primary-400 flex h-5 w-5 items-center justify-center rounded-full border border-gray-400 transition-all peer-checked:border-6" />
       {children}
     </label>
   );

--- a/src/components/common/RangeSlider.tsx
+++ b/src/components/common/RangeSlider.tsx
@@ -19,7 +19,7 @@ export default function RangeSlider({
 
   return (
     <div className="w-full">
-      <div className="mb-2">
+      <div className="relative mb-2">
         <input
           type="range"
           aria-valuemin={min}
@@ -31,11 +31,19 @@ export default function RangeSlider({
           step={step}
           value={value}
           onChange={(e) => onChange(Number(e.target.value))}
-          className="[&::-webkit-slider-thumb]:bg-primary-400 h-2 w-full cursor-pointer appearance-none rounded-lg border border-gray-200 bg-gray-100 [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:border-none [&::-webkit-slider-thumb]:shadow-md"
+          className="peer [&::-webkit-slider-thumb]:bg-primary-400 h-2 w-full cursor-pointer appearance-none rounded-lg border border-gray-200 bg-gray-100 [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:border-none [&::-webkit-slider-thumb]:shadow-md"
           style={{
             background: `linear-gradient(to right, #ffcbf4 0%, #ff61d5 ${percent}%, #f1f1f1 ${percent}%, #f1f1f1 100%)`,
           }}
         />
+        <span
+          style={{
+            left: `${percent}%`,
+          }}
+          className="absolute -top-6 hidden -translate-x-1/2 transform rounded border border-gray-300 bg-white px-2 py-1 text-xs font-medium text-black shadow peer-active:block"
+        >
+          {value}
+        </span>
       </div>
       <div className="flex w-full items-center justify-between">
         <span className="text-xs font-medium text-nowrap text-black">

--- a/src/components/game/FilterSidebar.tsx
+++ b/src/components/game/FilterSidebar.tsx
@@ -121,6 +121,7 @@ export default function FilterSidebar() {
         <RangeSlider
           min={15}
           max={120}
+          unit="분"
           step={5}
           value={playTime}
           onChange={setPlayTime}

--- a/src/components/main/MainBannerCarousel.tsx
+++ b/src/components/main/MainBannerCarousel.tsx
@@ -1,7 +1,11 @@
 'use client';
 import { mainBannerList } from '@/assets/mocks/mainBannerList';
 import Button from '@/components/common/Button';
-import { RiArrowRightLine } from '@remixicon/react';
+import {
+  RiArrowLeftSLine,
+  RiArrowRightLine,
+  RiArrowRightSLine,
+} from '@remixicon/react';
 import Image from 'next/image';
 import Link from 'next/link';
 import 'swiper/css';
@@ -52,10 +56,14 @@ export default function MainBannerCarousel() {
           loop={true}
           modules={[Navigation, Autoplay]}
           spaceBetween={8}
-          autoplay={{ delay: 3000, disableOnInteraction: false }} // 자동 슬라이드 설정
+          autoplay={{
+            delay: 3000,
+            disableOnInteraction: false,
+            pauseOnMouseEnter: true,
+          }}
           navigation={{
-            nextEl: '.swiper-button-next',
-            prevEl: '.swiper-button-prev',
+            nextEl: '.main-button-next',
+            prevEl: '.main-button-prev',
           }}
           breakpoints={{
             768: {
@@ -73,7 +81,7 @@ export default function MainBannerCarousel() {
             <SwiperSlide key={index}>
               <Link
                 href={`/games/${banner.gameId}`}
-                className="relative block aspect-square w-full overflow-hidden rounded-xl"
+                className="group relative block aspect-square w-full overflow-hidden rounded-xl"
               >
                 <Image
                   src={banner.src}
@@ -83,7 +91,7 @@ export default function MainBannerCarousel() {
                   className="absolute inset-0 h-full w-full object-cover"
                   priority={index === 0}
                 />
-                <div className="absolute right-0 bottom-0 left-0 bg-gradient-to-t from-black to-transparent px-6 py-8">
+                <div className="absolute right-0 bottom-0 left-0 bg-gradient-to-t from-black to-transparent px-6 py-8 transition-all group-hover:h-full group-hover:from-[#00000087] group-hover:to-[#00000087]">
                   <h3 className="line-clamp-2 text-2xl font-bold text-white">
                     {banner.title}
                   </h3>
@@ -94,15 +102,13 @@ export default function MainBannerCarousel() {
               </Link>
             </SwiperSlide>
           ))}
-          <div className="absolute top-1/2 left-1/2 z-20 flex w-full -translate-x-1/2 -translate-y-1/2 transform justify-between px-6 xl:w-[calc(50%+100px)]">
-            <div
-              className="swiper-button-next after:text-2xl!"
-              style={{ color: 'white' }}
-            ></div>
-            <div
-              className="swiper-button-prev after:text-2xl!"
-              style={{ color: 'white' }}
-            ></div>
+          <div className="pointer-events-none absolute top-1/2 left-1/2 z-20 flex w-full -translate-x-1/2 -translate-y-1/2 transform justify-between px-6 xl:w-[calc(50%+10rem)]">
+            <div className="main-button-prev">
+              <RiArrowLeftSLine className="h-10 w-10" />
+            </div>
+            <div className="main-button-next">
+              <RiArrowRightSLine className="h-10 w-10" />
+            </div>
           </div>
         </Swiper>
       </div>

--- a/src/components/main/NewAndHotGameSection.tsx
+++ b/src/components/main/NewAndHotGameSection.tsx
@@ -8,9 +8,9 @@ export default function NewAndHotGameSection() {
   return (
     <div className="inner">
       <h2 className="mb-8 flex items-center justify-between text-2xl font-bold md:text-3xl">
-        NEW & HOT
+        보드큐 랭킹
         <Link
-          href="/rank"
+          href="/ranking"
           className="group flex items-center gap-1 p-1 text-sm text-gray-900 hover:underline"
         >
           전체보기
@@ -18,8 +18,8 @@ export default function NewAndHotGameSection() {
         </Link>
       </h2>
       <div className="grid grid-cols-1 gap-15 md:grid-cols-2 md:gap-6">
-        <RankItemList games={games} title="NEW" />
-        <RankItemList games={games} title="HOT" />
+        <RankItemList games={games} title="전체" />
+        <RankItemList games={games} title="평점순" />
       </div>
     </div>
   );

--- a/src/components/main/RankItem.tsx
+++ b/src/components/main/RankItem.tsx
@@ -59,7 +59,6 @@ export default function RankItem({ game, index }: RankItemProps) {
             max_players={game.max_players}
             difficulty={game.difficulty}
             isLink={false}
-            size="md"
           />
         </div>
       </div>

--- a/src/components/main/RecommendedGameList.tsx
+++ b/src/components/main/RecommendedGameList.tsx
@@ -43,10 +43,10 @@ export default function RecommendedGameList({
       </Swiper>
       <div className="pointer-events-none absolute top-1/2 left-1/2 z-20 flex w-full -translate-x-1/2 -translate-y-1/2 transform justify-between px-4 lg:w-[calc(100%+120px)] lg:px-0">
         <button className="theme-button-prev pointer-events-auto">
-          <RiArrowLeftLine className="text-2xl" />
+          <RiArrowLeftLine />
         </button>
         <button className="theme-button-next pointer-events-auto">
-          <RiArrowRightLine className="text-2xl" />
+          <RiArrowRightLine />
         </button>
       </div>
     </div>

--- a/src/components/main/RecommendedGameListSkeleton.tsx
+++ b/src/components/main/RecommendedGameListSkeleton.tsx
@@ -22,11 +22,11 @@ export default function RecommendedGameListSkeleton() {
               />
             ))}
           </div>
-          <div className="absolute top-1/2 left-1/2 z-20 flex w-full -translate-x-1/2 -translate-y-1/2 transform justify-between px-4 lg:w-[calc(100%+120px)] lg:px-0">
-            <div className="theme-button-prev pointer-events-none opacity-50">
+          <div className="pointer-events-none absolute top-1/2 left-1/2 z-20 flex w-full -translate-x-1/2 -translate-y-1/2 transform justify-between px-4 lg:w-[calc(100%+120px)] lg:px-0">
+            <div className="theme-button-prev">
               <RiArrowLeftLine className="text-2xl" />
             </div>
-            <div className="theme-button-next pointer-events-none opacity-50">
+            <div className="theme-button-next">
               <RiArrowRightLine className="text-2xl" />
             </div>
           </div>

--- a/src/components/main/TrendingReviewCarousel.tsx
+++ b/src/components/main/TrendingReviewCarousel.tsx
@@ -17,40 +17,42 @@ export default function TrendingReviewCarousel({
   handleReviewClick,
 }: TrendingReviewCarouselProps) {
   return (
-    <div className="relative h-50 overflow-hidden" id="review">
-      <Swiper
-        slidesPerView={1}
-        direction={'vertical'}
-        spaceBetween={24}
-        loop={true}
-        autoplay={{ delay: 3000, disableOnInteraction: false }} // 자동 슬라이드 설정
-        modules={[Navigation, Autoplay]}
-        navigation={{
-          nextEl: '#review .theme-button-next',
-          prevEl: '#review .theme-button-prev',
-        }}
-        breakpoints={{
-          768: {
-            slidesPerView: 3,
-            direction: 'horizontal',
-          },
-        }}
-        className="h-full"
-      >
-        {reviews.map((review) => (
-          <SwiperSlide
-            key={review.review_id}
-            onClick={() => handleReviewClick(review)}
-          >
-            <ReviewItem
-              review={review}
-              isDisplayTitle={true}
-              isDisplayImage={true}
-              isDisplayDate={false}
-            />
-          </SwiperSlide>
-        ))}
-      </Swiper>
+    <div className="relative h-50" id="review">
+      <div className="overflow-hidden">
+        <Swiper
+          slidesPerView={1}
+          direction={'vertical'}
+          spaceBetween={24}
+          loop={true}
+          autoplay={{ delay: 3000, disableOnInteraction: false }} // 자동 슬라이드 설정
+          modules={[Navigation, Autoplay]}
+          navigation={{
+            nextEl: '#review .theme-button-next',
+            prevEl: '#review .theme-button-prev',
+          }}
+          breakpoints={{
+            768: {
+              slidesPerView: 3,
+              direction: 'horizontal',
+            },
+          }}
+          className="h-full"
+        >
+          {reviews.map((review) => (
+            <SwiperSlide
+              key={review.review_id}
+              onClick={() => handleReviewClick(review)}
+            >
+              <ReviewItem
+                review={review}
+                isDisplayTitle={true}
+                isDisplayImage={true}
+                isDisplayDate={false}
+              />
+            </SwiperSlide>
+          ))}
+        </Swiper>
+      </div>
       <div className="pointer-events-none absolute top-1/2 left-1/2 z-20 hidden w-full -translate-x-1/2 -translate-y-1/2 transform justify-between px-4 md:flex lg:w-[calc(100%+120px)] lg:px-0">
         <button className="theme-button-prev pointer-events-auto">
           <RiArrowLeftLine className="text-2xl" />


### PR DESCRIPTION
PR템플릿

## 🔗 관련 이슈
- Closes #74


## ✨ 작업 개요
* 메인 페이지 및 보드픽(추천) 관련 UI 개선 및 컴포넌트 리팩토링
* 필터 및 폼 컴포넌트(Checkbox, Radio, RangeSlider) 디자인 개선
* 메인페이지 랭킹/리뷰/추천 섹션 기능 및 스타일 수정


## ✅ 작업 상세 내용

### ◾ 메인 페이지 UI 개선

* 메인 배너(MainBannerCarousel)

  * autoplay 동작: 마우스 hover 시 정지되도록 수정
  * Swiper 버튼 커스텀 및 hover 디자인 추가

* NEW & HOT → 보드큐 랭킹 섹션 개편

  * 제목을 '보드큐 랭킹'으로 변경
  * 링크 경로 `/rank` → `/ranking` 으로 변경
  * 탭 제목을 'NEW' / 'HOT' → '전체' / '평점순'으로 변경
  * `GameTags` props 구조 조정 (size 제거, v2 마이그레이션 준비)

* 리뷰 섹션

  * Swiper의 `overflow-hidden` 처리 위치 조정으로 버튼 클릭 가능하게 수정

* 사용자 맞춤 추천 섹션

  * Skeleton의 Swiper 버튼을 비활성화(`pointer-events-none`) 처리
  * Swiper 버튼 아이콘 제거 및 커스텀 스타일 적용 (global.css 수정 포함)


### ◾ 필터 사이드바 개선 (FilterSidebar)

* RangeSlider에 현재 값 표시 툴팁 추가

  * 슬라이더 드래그 시만 보이도록 `peer-active:block` 사용
  * `absolute + left` 계산으로 핸들 위치에 맞춰 표시되도록 구현
* RangeSlider에 단위(unit) 추가


### ◾ 공통 컴포넌트 스타일 개선

* Checkbox

  * 체크되지 않은 상태에서 아이콘 숨김 (`text-transparent`)
  * 체크 시 흰색 아이콘 표시 (`peer-checked:text-white`)
* Radio

  * 체크 아이콘 제거 및 `peer-checked:border-6`로 스타일 표현

### ◾ 보드픽 페이지 정렬 개선

* GradientLayout에 `relative` 추가
* IntroSection에 `absolute inset-0` 설정으로 수직 중앙 정렬 처리

