### PR TITLE
feat: 게임리스트 필터 개선(플레이시간 최소/최대 선택) (#99)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,7 +10,7 @@ const nextConfig: NextConfig = {
     return config;
   },
   images: {
-    domains: ['images.unsplash.com', 'boardlife.co.kr', 'boardq.o-r.kr'],
+    // domains: ['images.unsplash.com', 'boardlife.co.kr', 'boardq.o-r.kr'],
     remotePatterns: [
       {
         protocol: 'https',
@@ -22,7 +22,7 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 'boardlife.co.kr',
         port: '',
-        pathname: '/data/photo/**',
+        pathname: '/**',
       },
       {
         protocol: 'https',
@@ -34,6 +34,12 @@ const nextConfig: NextConfig = {
         hostname: 'kr.object.ncloudstorage.com',
         port: '',
         pathname: '/boardq/**',
+      },
+      {
+        protocol: 'https',
+        hostname: 'boardq.o-r.kr',
+        port: '',
+        pathname: '/image/**',
       },
     ],
   },

--- a/src/components/common/DualRangeSlider.tsx
+++ b/src/components/common/DualRangeSlider.tsx
@@ -1,0 +1,116 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+interface DualRangeSliderProps {
+  min: number;
+  max: number;
+  step?: number;
+  initialMin?: number;
+  initialMax?: number;
+  onChange: (values: { min: number; max: number }) => void;
+  unit?: string;
+}
+
+export default function DualRangeSlider({
+  min,
+  max,
+  step = 1,
+  initialMin = min,
+  initialMax = max,
+  onChange,
+  unit,
+}: DualRangeSliderProps) {
+  const [currentMin, setCurrentMin] = useState(initialMin);
+  const [currentMax, setCurrentMax] = useState(initialMax);
+  const sliderRef = useRef<HTMLDivElement>(null);
+
+  // useEffect를 사용하여 부모 컴포넌트의 prop이 변경될 때 상태 업데이트
+  useEffect(() => {
+    setCurrentMin(initialMin);
+    setCurrentMax(initialMax);
+  }, [initialMin, initialMax]);
+
+  // 현재 값과 전체 범위에 따른 퍼센트 계산
+  const minPercent = ((currentMin - min) / (max - min)) * 100;
+  const maxPercent = ((currentMax - min) / (max - min)) * 100;
+
+  // 핸들 드래그 이벤트
+  const startDrag = (e: React.MouseEvent, type: 'min' | 'max') => {
+    e.preventDefault();
+    const onMouseMove = (moveEvent: MouseEvent) => {
+      if (!sliderRef.current) return;
+      const rect = sliderRef.current.getBoundingClientRect();
+      const clientX = moveEvent.clientX;
+      const newValue = ((clientX - rect.left) / rect.width) * (max - min) + min;
+      const roundedValue = Math.round(newValue / step) * step;
+
+      if (type === 'min') {
+        const newMin = Math.min(Math.max(min, roundedValue), currentMax - step);
+        setCurrentMin(newMin);
+        onChange({ min: newMin, max: currentMax });
+      } else {
+        const newMax = Math.max(Math.min(max, roundedValue), currentMin + step);
+        setCurrentMax(newMax);
+        onChange({ min: currentMin, max: newMax });
+      }
+    };
+
+    const onMouseUp = () => {
+      window.removeEventListener('mousemove', onMouseMove);
+      window.removeEventListener('mouseup', onMouseUp);
+    };
+
+    window.addEventListener('mousemove', onMouseMove);
+    window.addEventListener('mouseup', onMouseUp);
+  };
+
+  return (
+    <div className="w-full">
+      <div ref={sliderRef} className="relative mb-2 h-2 rounded-lg">
+        {/* 전체 배경 바 */}
+        <div className="absolute inset-y-0 z-0 h-full w-full rounded-lg bg-gray-100" />
+
+        {/* 채워진 레인지 바 */}
+        <div
+          className="bg-primary-400 absolute inset-y-0 z-10 h-full rounded-lg"
+          style={{
+            left: `${minPercent}%`,
+            right: `${100 - maxPercent}%`,
+            backgroundColor: '#ff61d5',
+          }}
+        />
+
+        {/* 최소값 핸들 */}
+        <span
+          className="bg-primary-400 absolute top-1/2 z-20 h-4 w-4 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full shadow-md"
+          style={{ left: `${minPercent}%` }}
+          onMouseDown={(e) => startDrag(e, 'min')}
+        >
+          <span className="text-primary-400 absolute -bottom-full left-1/2 -translate-x-1/2 text-xs font-medium text-nowrap">
+            {currentMin}
+          </span>
+        </span>
+        {/* 최대값 핸들 */}
+        <span
+          className="bg-primary-400 absolute top-1/2 z-20 h-4 w-4 -translate-x-1/2 -translate-y-1/2 cursor-pointer rounded-full shadow-md"
+          style={{ left: `${maxPercent}%` }}
+          onMouseDown={(e) => startDrag(e, 'max')}
+        >
+          <span className="text-primary-400 absolute -bottom-full left-1/2 -translate-x-1/2 text-xs font-medium text-nowrap">
+            {currentMax}
+          </span>
+        </span>
+      </div>
+      {/* 현재 값 표시 */}
+      <div className="mt-6 flex w-full items-center justify-between">
+        <span className="text-xs font-medium text-nowrap text-black">
+          {`${min}`}
+        </span>
+        <span className="text-xs font-medium text-nowrap text-black">
+          {`${max}${unit ? `(${unit})` : ''}`}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/src/components/game/FilterSidebar.tsx
+++ b/src/components/game/FilterSidebar.tsx
@@ -4,7 +4,6 @@ import Accordion from '@/components/common/Accordian';
 import Button from '@/components/common/Button';
 import Checkbox from '@/components/common/Checkbox';
 import Radio from '@/components/common/Radio';
-import RangeSlider from '@/components/common/RangeSlider';
 import {
   ageGroups,
   categoryList,
@@ -15,6 +14,7 @@ import {
 import { RiResetRightLine } from '@remixicon/react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
+import DualRangeSlider from '../common/DualRangeSlider';
 
 export default function FilterSidebar() {
   const router = useRouter();
@@ -23,8 +23,9 @@ export default function FilterSidebar() {
   const [genres, setGenres] = useState<string[]>([]);
   const [categories, setCategories] = useState<string[]>([]);
   const [players, setPlayers] = useState<string | null>(null);
-  const [playTime, setPlayTime] = useState<number>(0);
-  const [difficulty, setDifficulty] = useState<string>(''); // 1~5
+  const [minPlayTime, setMinPlayTime] = useState<number>(0);
+  const [maxPlayTime, setMaxPlayTime] = useState<number>(0);
+  const [difficulty, setDifficulty] = useState<string>('');
   const [age, setAge] = useState<number | null>(null);
   const [keyword, setKeyword] = useState<string>('');
 
@@ -39,8 +40,10 @@ export default function FilterSidebar() {
     const playersParam = searchParams.get('players');
     if (playersParam) setPlayers(playersParam);
 
-    const timeParam = searchParams.get('playtime_min_minutes');
-    if (timeParam) setPlayTime(Number(timeParam));
+    const minTimeParam = searchParams.get('playtime_min_minutes');
+    const maxTimeParam = searchParams.get('playtime_max_minutes');
+    if (minTimeParam) setMinPlayTime(Number(minTimeParam));
+    if (maxTimeParam) setMaxPlayTime(Number(maxTimeParam));
 
     const diffParam = searchParams.get('difficulty');
     if (diffParam) setDifficulty(diffParam);
@@ -72,7 +75,10 @@ export default function FilterSidebar() {
     if (categories.length) params.set('categories', categories.join(','));
     if (genres.length) params.set('genres', genres.join(','));
     if (players) params.set('players', players);
-    if (playTime > 0) params.set('playtime_min_minutes', String(playTime));
+    if (minPlayTime > 0)
+      params.set('playtime_min_minutes', String(minPlayTime));
+    if (maxPlayTime > 0)
+      params.set('playtime_max_minutes', String(maxPlayTime));
     if (difficulty && difficulty !== '0')
       params.set('difficulty', String(difficulty));
     if (age !== null) params.set('age', String(age));
@@ -85,7 +91,8 @@ export default function FilterSidebar() {
     setCategories([]);
     setGenres([]);
     setPlayers(null);
-    setPlayTime(0);
+    setMinPlayTime(0);
+    setMaxPlayTime(0);
     setDifficulty('');
     setAge(null);
     setKeyword('');
@@ -166,14 +173,18 @@ export default function FilterSidebar() {
         </Accordion>
 
         <div>
-          <h3 className="mb-2 font-medium">최소 플레이 시간</h3>
-          <RangeSlider
-            min={15}
+          <h3 className="mb-2 font-medium">플레이 시간</h3>
+          <DualRangeSlider
+            min={0}
             max={120}
             unit="분"
             step={5}
-            value={playTime}
-            onChange={setPlayTime}
+            initialMin={minPlayTime}
+            initialMax={maxPlayTime}
+            onChange={({ min, max }) => {
+              setMinPlayTime(min);
+              setMaxPlayTime(max);
+            }}
           />
         </div>
 


### PR DESCRIPTION
## 🔗 관련 이슈

* Closes #99


## ✨ 작업 개요

* 게임리스트 필터 기능 개선
* DualRangeSlider 컴포넌트 신규 도입
* 외부 이미지 도메인 처리 방식 통일


## ✅ 작업 상세 내용

### 1. 게임리스트 필터 개선 (`feat: 게임리스트 필터 기능 개선`)

* 기존 `RangeSlider` → `DualRangeSlider` 교체
* 최소/최대 플레이 시간 범위 설정 가능
* 쿼리스트링에 `playtime_min_minutes`, `playtime_max_minutes` 분리 저장
* 필터 초기화 시 range값 초기화되도록 수정

### 2. DualRangeSlider 컴포넌트 추가 (`feat: DualRangeSlider 컴포넌트 추가`)

* 최소/최대 값을 드래그로 조절하는 이중 슬라이더 구현
* min/max/step/초기값 설정 가능
* 콜백을 통해 부모 컴포넌트에서 값 관리 가능

### 3. 이미지 도메인 처리 방식 개선 (`chore: 이미지 도메인 설정 remotePatterns 방식으로 통일`)

* `images.domains` 항목 주석 처리
* `images.remotePatterns` 내 세부 경로 재정의

  * `boardlife.co.kr` 경로 확장
  * `boardq.o-r.kr` 하위 이미지 경로 추가


## 📸 스크린샷 (UI 변경 시)
![dualrangeslider](https://github.com/user-attachments/assets/712b48a9-d754-42bc-ba9e-386c880e9d6c)


## 📝 기타

* `DualRangeSlider`는 범용 컴포넌트로 별도 위치(`components/common`)에 배치함
* 이미지 remotePatterns는 향후 이미지 경로 변경에 유연하게 대응 가능하도록 구성함

