### PR TITLE
feat: 랭킹 페이지 API 연동 (#84)

### DIFF
--- a/src/app/api/likes/remove/route.ts
+++ b/src/app/api/likes/remove/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 
 export async function POST(req: NextRequest) {
   const token = await getAccessToken();
+  console.log('token : ', token);
   const { game_id } = await req.json();
 
   const res = await fetch(`https://boardq.o-r.kr/api/v1/likes/remove/`, {

--- a/src/app/ranking/_components/RankingItem.tsx
+++ b/src/app/ranking/_components/RankingItem.tsx
@@ -9,7 +9,7 @@ interface RankingItemProps {
   game: GameRankingItem;
 }
 
-const rankColorMap: Record<number, string> = {
+export const rankColorMap: Record<number, string> = {
   1: 'text-primary-400',
   2: 'text-primary-600',
   3: 'text-primary-800',
@@ -20,7 +20,7 @@ export default function RankingItem({ rank, game }: RankingItemProps) {
   return (
     <>
       <div className={cn('py-4 text-5xl sm:text-right', rankClass)}>{rank}</div>
-      <Link href={`/game/${game.game_id}`}>
+      <Link href={`/games/${game.game_id}`}>
         <div className="flex items-center gap-4 py-4">
           <Image
             src={game.thumbnail_url}

--- a/src/app/ranking/_components/RankingItemSkeleton.tsx
+++ b/src/app/ranking/_components/RankingItemSkeleton.tsx
@@ -1,0 +1,38 @@
+import { rankColorMap } from '@/app/ranking/_components/RankingItem';
+
+export default function RankingSkeleton() {
+  return (
+    <div className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-6 sm:grid-cols-[auto_1fr_auto_auto]">
+      {Array.from({ length: 10 }).map((_, idx) => (
+        <RankingItemSkeletonItem key={idx} rank={idx + 1} />
+      ))}
+    </div>
+  );
+}
+
+function SkeletonBox({ className }: { className: string }) {
+  return <div className={`animate-pulse rounded bg-gray-200 ${className}`} />;
+}
+
+function RankingItemSkeletonItem({ rank }: { rank: number }) {
+  return (
+    <>
+      <div className={`py-4 text-5xl ${rankColorMap[rank] || 'text-black'}`}>
+        {rank}
+      </div>
+      <div className="flex items-center gap-4 py-4">
+        <SkeletonBox className="h-[125px] w-[100px]" />
+        <div className="flex flex-col gap-2">
+          <SkeletonBox className="h-4 w-32" />
+          <SkeletonBox className="h-3 w-20" />
+        </div>
+      </div>
+      <div className="hidden flex-col items-center gap-y-2.5 text-sm sm:flex">
+        <SkeletonBox className="h-4 w-8" />
+      </div>
+      <div className="hidden flex-col items-center gap-y-2.5 text-sm sm:flex">
+        <SkeletonBox className="h-4 w-12" />
+      </div>{' '}
+    </>
+  );
+}

--- a/src/app/ranking/_components/RankingList.tsx
+++ b/src/app/ranking/_components/RankingList.tsx
@@ -1,6 +1,6 @@
+import RankingItem from '@/app/ranking/_components/RankingItem';
 import { GameRankingItem } from '@/types/game/gameRanking';
 import { cn } from '@/utils/cn';
-import RankingItem from './RankingItem';
 
 interface RankingListProps {
   games: GameRankingItem[];

--- a/src/app/ranking/_components/RankingPageContent.tsx
+++ b/src/app/ranking/_components/RankingPageContent.tsx
@@ -1,16 +1,20 @@
 'use client';
 
-import { gameRankingData } from '@/assets/mocks/gameRankingData';
-import RankingList from '@/components/ranking/RankingList';
+import RankingSkeleton from '@/app/ranking/_components/RankingItemSkeleton';
+import RankingList from '@/app/ranking/_components/RankingList';
 import { GameRankingItem } from '@/types/game/gameRanking';
 import dynamic from 'next/dynamic';
+import { Suspense } from 'react';
 
 const Breadcrumbs = dynamic(() => import('@/components/layout/Breadcrumbs'), {
   ssr: false,
 });
-const RankingTab = dynamic(() => import('@/components/ranking/RankingTab'), {
-  ssr: false,
-});
+const RankingTab = dynamic(
+  () => import('@/app/ranking/_components/RankingTab'),
+  {
+    ssr: false,
+  }
+);
 
 interface RankingPageContentProps {
   games: GameRankingItem[];
@@ -18,11 +22,13 @@ interface RankingPageContentProps {
 
 export default function RankingPageContent({ games }: RankingPageContentProps) {
   return (
-    <main className="inner flex flex-1 flex-col gap-6 pt-6 pb-40 text-center">
+    <main className="inner flex flex-1 flex-col gap-6 pt-6 pb-40 text-center lg:px-2">
       <Breadcrumbs />
       <h1 className="text-4xl font-bold">보드큐 랭킹</h1>
       <RankingTab />
-      <RankingList games={gameRankingData} />
+      <Suspense fallback={<RankingSkeleton />}>
+        <RankingList games={games} />
+      </Suspense>
     </main>
   );
 }

--- a/src/app/ranking/_components/RankingPageContent.tsx
+++ b/src/app/ranking/_components/RankingPageContent.tsx
@@ -2,13 +2,11 @@
 
 import RankingSkeleton from '@/app/ranking/_components/RankingItemSkeleton';
 import RankingList from '@/app/ranking/_components/RankingList';
+import Breadcrumbs from '@/components/layout/Breadcrumbs';
 import { GameRankingItem } from '@/types/game/gameRanking';
 import dynamic from 'next/dynamic';
 import { Suspense } from 'react';
 
-const Breadcrumbs = dynamic(() => import('@/components/layout/Breadcrumbs'), {
-  ssr: false,
-});
 const RankingTab = dynamic(
   () => import('@/app/ranking/_components/RankingTab'),
   {

--- a/src/app/ranking/_components/RankingTab.tsx
+++ b/src/app/ranking/_components/RankingTab.tsx
@@ -5,7 +5,6 @@ import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 
 const ORDER_TABS = [
   { label: '전체', href: 'popularity' },
-  { label: '좋아요', href: 'like' },
   { label: '평점', href: 'rating' },
   { label: '리뷰 많은 순', href: 'review' },
 ];

--- a/src/app/ranking/page.tsx
+++ b/src/app/ranking/page.tsx
@@ -1,12 +1,21 @@
-import RankingPageContent from '@/components/ranking/RankingPageContent';
+import RankingPageContent from '@/app/ranking/_components/RankingPageContent';
 import { fetcher } from '@/lib/fetcher';
-import { GameRankingItem } from '@/types/game/gameRanking';
+import { GameListResponse } from '@/types/game/gameRanking';
 
-async function getRankingGames(sortBy: string) {
-  return await fetcher<GameRankingItem[]>(`/games?sort_by=${sortBy}`);
+interface RankingPageProp {
+  searchParams: Promise<{ sort?: string | string[] }>;
 }
 
-export default async function RankingPage() {
-  const rankingGames = await getRankingGames('rating');
-  return <RankingPageContent games={rankingGames} />;
+export default async function RankingPage({
+  searchParams,
+}: {
+  searchParams: { [key: string]: string | string[] | undefined };
+}) {
+  const params = await searchParams;
+  const sort = typeof params.sort === 'string' ? params.sort : 'popularity';
+  const endpoint = `/games?sort_by=${sort}&page_size=10`;
+  const res = await fetcher<GameListResponse>(endpoint, { cache: 'no-store' });
+  const games = res.results;
+
+  return <RankingPageContent games={games} />;
 }

--- a/src/components/layout/Header/UserMenu.tsx
+++ b/src/components/layout/Header/UserMenu.tsx
@@ -9,18 +9,6 @@ export function UserMenu({ user }: { user: User }) {
   return (
     <div className="flex shrink-0 items-center gap-8 text-sm font-semibold">
       <Link href={'/my-page'} className="flex items-center gap-2">
-        {/* <ImageWithFallback
-          src={
-            user.profile_image
-              ? `https://boardq.o-r.kr/media/${user.profile_image}`
-              : DEFAULT_PROFILE_IMAGE
-          }
-          alt="프로필"
-          width={32}
-          height={32}
-          priority
-          className="rounded-full"
-        /> */}
         <div className="relative size-8 overflow-hidden rounded-full">
           <ProfileImage
             src={user.profile_image}

--- a/src/types/game/gameRanking.ts
+++ b/src/types/game/gameRanking.ts
@@ -19,10 +19,12 @@ export interface GameRankingItem {
   is_liked: boolean;
 }
 
-export const VALID_SORTS = [
-  'popularity',
-  'likes',
-  'rating',
-  'reviews',
-] as const;
+export const VALID_SORTS = ['popularity', 'rating', 'reviews'] as const;
 export type ValidSort = (typeof VALID_SORTS)[number];
+
+export interface GameListResponse {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: GameRankingItem[];
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #84 #50 

## ✨ 작업 개요

- 게임 랭킹 페이지 구현 및 API 연동

## ✅ 작업 상세 내용

- 게임 랭킹 페이지(/ranking) API 연동
  - 서버 컴포넌트에서 searchParams를 이용해 정렬 기준(sort) 파라미터 처리
  - 기존 components/ranking/* 경로의 컴포넌트 → app/ranking/_components/로 이동
  - 스켈레톤 UI 추가 (suspense로 처리)

## 스크린샷 
<img width="838" height="744" alt="스크린샷 2025-08-18 오후 4 11 04" src="https://github.com/user-attachments/assets/1ef9add5-8461-44e4-b5c0-7e9118d408ee" />

<img width="844" height="789" alt="스크린샷 2025-08-18 오후 4 11 15" src="https://github.com/user-attachments/assets/377e772b-09eb-4eb3-8dad-8f33ecd18874"
 />

<img width="330" height="490" alt="스크린샷 2025-08-18 오후 4 11 32" src="https://github.com/user-attachments/assets/bd9fea73-c81a-49f1-a0bd-fdb79f6cc12e" />
