### PR TITLE
feat: 게임리스트페이지 무한스크롤 구현, 스켈레톤 UI 추가 (#102)

### DIFF
--- a/src/app/games/_components/FilterSidebar.tsx
+++ b/src/app/games/_components/FilterSidebar.tsx
@@ -3,6 +3,7 @@
 import Accordion from '@/components/common/Accordian';
 import Button from '@/components/common/Button';
 import Checkbox from '@/components/common/Checkbox';
+import DualRangeSlider from '@/components/common/DualRangeSlider';
 import Radio from '@/components/common/Radio';
 import {
   ageGroups,
@@ -14,7 +15,6 @@ import {
 import { RiResetRightLine } from '@remixicon/react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
-import DualRangeSlider from '../common/DualRangeSlider';
 
 export default function FilterSidebar() {
   const router = useRouter();

--- a/src/app/games/_components/FilterSidebarSkeleton.tsx
+++ b/src/app/games/_components/FilterSidebarSkeleton.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import Button from '@/components/common/Button';
+import { Skeleton } from '@/components/common/Skeleton';
+
+export default function FilterSidebarSkeleton() {
+  return (
+    <aside className="w-full rounded-2xl border border-gray-200 px-4 py-6">
+      {/* 헤더 */}
+      <div className="mb-4 flex items-center justify-between">
+        <Skeleton className="h-5 w-16" /> {/* 필터 제목 */}
+        <Skeleton className="h-4 w-10" /> {/* 초기화 */}
+      </div>
+
+      <div className="space-y-6">
+        {/* 카테고리 */}
+        <div>
+          <div className="flex cursor-default items-center justify-between">
+            <Skeleton className="h-6 w-20" />
+            <Skeleton className="h-5 w-5 rounded-full" />
+          </div>
+        </div>
+
+        {/* 장르 */}
+        <div>
+          <div className="flex cursor-default items-center justify-between">
+            <Skeleton className="h-6 w-20" />
+            <Skeleton className="h-5 w-5 rounded-full" />
+          </div>
+        </div>
+
+        {/* 인원수 */}
+        <div>
+          <div className="mb-4 flex cursor-default items-center justify-between">
+            <Skeleton className="h-6 w-20" />
+            <Skeleton className="h-5 w-5 rounded-full" />
+          </div>
+          <div className="grid grid-cols-3 gap-2">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-8 w-full rounded" />
+            ))}
+          </div>
+        </div>
+
+        {/* 연령대 */}
+        <div>
+          <div className="mb-4 flex cursor-default items-center justify-between">
+            <Skeleton className="h-6 w-20" />
+            <Skeleton className="h-5 w-5 rounded-full" />
+          </div>
+          <div className="flex flex-col gap-2">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-4 w-20" />
+            ))}
+          </div>
+        </div>
+
+        {/* 플레이 시간 */}
+        <div>
+          <Skeleton className="mb-2 h-6 w-24" />
+          <Skeleton className="h-3 w-full rounded" /> {/* 슬라이더 */}
+        </div>
+
+        {/* 난이도 */}
+        <div>
+          <Skeleton className="mb-2 h-4 w-16" />
+          <div className="grid grid-cols-3 gap-2">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <Skeleton key={i} className="h-8 w-full rounded" />
+            ))}
+          </div>
+        </div>
+
+        {/* 검색 버튼 */}
+        <Button
+          variant="primary"
+          size="md"
+          disabled
+          className="animation-pulse w-full opacity-50"
+        >
+          검색
+        </Button>
+      </div>
+    </aside>
+  );
+}

--- a/src/app/games/_components/GameListSection.tsx
+++ b/src/app/games/_components/GameListSection.tsx
@@ -1,6 +1,8 @@
 import GameList from '@/components/game/GameList';
+import GameListSkeleton from '@/components/game/GameListSkeleton';
 import { useInfiniteGames } from '@/hooks/useInfiniteGames';
 import { GameListItem } from '@/types/game/game';
+import { RiArrowDownSLine } from '@remixicon/react';
 import { useEffect } from 'react';
 import SortDropdown from './SortDropdown';
 interface GameListSectionProps {
@@ -37,7 +39,26 @@ export default function GameListSection({
     };
   }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
 
-  if (status === 'pending') return <p>불러오는 중...</p>;
+  if (status === 'pending')
+    return (
+      <section>
+        <div className="mb-4 flex items-center justify-between">
+          <div className="flex items-center text-sm text-gray-600">
+            총
+            <span className="ml-1 inline-block h-4 w-8 animate-pulse rounded bg-gray-200" />
+            개
+          </div>
+          <button
+            type="button"
+            className="flex cursor-pointer items-center justify-start gap-1 text-base font-medium text-black"
+          >
+            정렬
+            <RiArrowDownSLine className="h-4 w-4" />
+          </button>
+        </div>
+        <GameListSkeleton imageRatio="1:1" count={12} />
+      </section>
+    );
   if (status === 'error') return <p>에러 발생</p>;
 
   return (
@@ -50,7 +71,11 @@ export default function GameListSection({
       {/* 카드 그리드 */}
       <GameList games={games} columnNumber={3} imageRatio="1:1" />
 
-      {isFetchingNextPage && <p>불러오는 중...</p>}
+      {isFetchingNextPage && (
+        <div className="mt-6">
+          <GameListSkeleton imageRatio="1:1" count={12} />
+        </div>
+      )}
       {!hasNextPage && <p>더 이상 데이터가 없습니다.</p>}
     </section>
   );

--- a/src/app/games/_components/GameListSection.tsx
+++ b/src/app/games/_components/GameListSection.tsx
@@ -1,15 +1,45 @@
 import GameList from '@/components/game/GameList';
+import { useInfiniteGames } from '@/hooks/useInfiniteGames';
 import { GameListItem } from '@/types/game/game';
+import { useEffect } from 'react';
 import SortDropdown from './SortDropdown';
-
 interface GameListSectionProps {
   total: number;
   gameListData: GameListItem[];
 }
+
 export default function GameListSection({
   total,
   gameListData,
 }: GameListSectionProps) {
+  const { data, fetchNextPage, hasNextPage, isFetchingNextPage, status } =
+    useInfiniteGames();
+
+  // 초기데이터를 react-query 캐시에 seed
+  const games = data?.pages.flatMap((page) => page.results) ?? gameListData;
+
+  // 스크롤 이벤트로 다음 페이지 호출
+  useEffect(() => {
+    function onScroll() {
+      if (
+        window.innerHeight + window.scrollY >=
+          document.body.offsetHeight - 200 &&
+        hasNextPage &&
+        !isFetchingNextPage
+      ) {
+        fetchNextPage();
+      }
+    }
+
+    window.addEventListener('scroll', onScroll);
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+    };
+  }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  if (status === 'pending') return <p>불러오는 중...</p>;
+  if (status === 'error') return <p>에러 발생</p>;
+
   return (
     <section>
       <div className="mb-4 flex items-center justify-between">
@@ -18,7 +48,10 @@ export default function GameListSection({
       </div>
 
       {/* 카드 그리드 */}
-      <GameList games={gameListData} columnNumber={3} imageRatio="1:1" />
+      <GameList games={games} columnNumber={3} imageRatio="1:1" />
+
+      {isFetchingNextPage && <p>불러오는 중...</p>}
+      {!hasNextPage && <p>더 이상 데이터가 없습니다.</p>}
     </section>
   );
 }

--- a/src/app/games/_components/GameListUI.tsx
+++ b/src/app/games/_components/GameListUI.tsx
@@ -1,15 +1,19 @@
 'use client';
 import GameListSection from '@/app/games/_components/GameListSection';
+import BreadcrumbsSkeleton from '@/components/layout/BreadcrumbsSkeleton';
 import Grid from '@/components/layout/Grid';
 import { GameListResponse } from '@/types/game/game';
 import dynamic from 'next/dynamic';
+import FilterSidebarSkeleton from './FilterSidebarSkeleton';
 
 const Breadcrumbs = dynamic(() => import('@/components/layout/Breadcrumbs'), {
+  loading: () => <BreadcrumbsSkeleton />,
   ssr: false,
 });
 const FilterSidebar = dynamic(
   () => import('@/app/games/_components/FilterSidebar'),
   {
+    loading: () => <FilterSidebarSkeleton />,
     ssr: false,
   }
 );

--- a/src/app/games/_components/GameListUI.tsx
+++ b/src/app/games/_components/GameListUI.tsx
@@ -7,9 +7,12 @@ import dynamic from 'next/dynamic';
 const Breadcrumbs = dynamic(() => import('@/components/layout/Breadcrumbs'), {
   ssr: false,
 });
-const FilterSidebar = dynamic(() => import('@/components/game/FilterSidebar'), {
-  ssr: false,
-});
+const FilterSidebar = dynamic(
+  () => import('@/app/games/_components/FilterSidebar'),
+  {
+    ssr: false,
+  }
+);
 
 export default function GameListUI({
   gameListData,

--- a/src/components/common/Skeleton.tsx
+++ b/src/components/common/Skeleton.tsx
@@ -1,0 +1,3 @@
+export function Skeleton({ className = '' }: { className?: string }) {
+  return <div className={`animate-pulse rounded bg-gray-200 ${className}`} />;
+}

--- a/src/components/game/GameListSkeleton.tsx
+++ b/src/components/game/GameListSkeleton.tsx
@@ -1,0 +1,57 @@
+import { cn } from '@/utils/cn';
+
+interface GameListSkeletonProps {
+  columnNumber?: number;
+  imageRatio?: '1:1' | '4:5' | '2:3';
+  count?: number;
+}
+
+const ratioClasses = {
+  '1:1': 'aspect-square',
+  '4:5': 'aspect-[4/5]',
+  '2:3': 'aspect-[2/3]',
+};
+
+export default function GameListSkeleton({
+  columnNumber = 3,
+  imageRatio = '4:5',
+  count = 6,
+}: GameListSkeletonProps) {
+  return (
+    <div
+      className={cn(
+        `grid grid-cols-2 gap-6`,
+        columnNumber === 3 && 'lg:grid-cols-3',
+        columnNumber === 4 && 'lg:grid-cols-4',
+        columnNumber === 5 && 'lg:grid-cols-5',
+        columnNumber === 6 && 'lg:grid-cols-6'
+      )}
+    >
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} className="flex flex-col gap-4 overflow-hidden rounded-xl">
+          {/* 이미지 영역 */}
+          <div
+            className={cn(
+              'relative w-full animate-pulse overflow-hidden rounded-xl bg-gray-200',
+              ratioClasses[imageRatio]
+            )}
+          />
+
+          {/* 텍스트 영역 */}
+          <div className="flex flex-col gap-2">
+            <div className="h-4 w-3/4 animate-pulse rounded bg-gray-200" />
+            <div className="flex gap-4">
+              <div className="h-3 w-8 animate-pulse rounded bg-gray-200" />
+              <div className="h-3 w-8 animate-pulse rounded bg-gray-200" />
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <div className="h-5 w-12 animate-pulse rounded-full bg-gray-200" />
+              <div className="h-5 w-12 animate-pulse rounded-full bg-gray-200" />
+              <div className="h-5 w-12 animate-pulse rounded-full bg-gray-200" />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/layout/BreadcrumbsSkeleton.tsx
+++ b/src/components/layout/BreadcrumbsSkeleton.tsx
@@ -1,0 +1,30 @@
+// components/common/BreadcrumbsSkeleton.tsx
+'use client';
+
+import { Skeleton } from '@/components/common/Skeleton';
+import { RiArrowRightSLine } from '@remixicon/react';
+
+export default function BreadcrumbsSkeleton() {
+  return (
+    <nav className="my-2 text-xs text-gray-500 md:text-sm">
+      <ol className="flex items-center">
+        {/* 홈 */}
+        <li className="flex items-center">
+          <Skeleton className="h-3 w-8 md:h-4 md:w-10" />
+        </li>
+
+        {/* 화살표 + 1단계 */}
+        <li className="flex items-center">
+          <RiArrowRightSLine className="mx-1 w-4 text-gray-300" />
+          <Skeleton className="h-3 w-12 md:h-4 md:w-16" />
+        </li>
+
+        {/* 화살표 + 2단계 (옵션) */}
+        <li className="flex items-center">
+          <RiArrowRightSLine className="mx-1 w-4 text-gray-300" />
+          <Skeleton className="h-3 w-16 md:h-4 md:w-20" />
+        </li>
+      </ol>
+    </nav>
+  );
+}

--- a/src/hooks/games/useGameFilters.ts
+++ b/src/hooks/games/useGameFilters.ts
@@ -1,0 +1,19 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+
+export function useGameFilters() {
+  const searchParams = useSearchParams();
+  return {
+    keyword: searchParams.get('keyword') ?? '',
+    page: Number(searchParams.get('page') ?? 1),
+    pageSize: Number(searchParams.get('page_size') ?? 12),
+    categories: searchParams.get('categories')?.split(',') ?? [],
+    genres: searchParams.get('genres')?.split(',') ?? [],
+    players: Number(searchParams.get('players') ?? 0),
+    playtime_min_minutes: Number(searchParams.get('playtime_min_minutes') ?? 0),
+    playtime_max_minutes: Number(searchParams.get('playtime_max_minutes') ?? 0),
+    difficulty: searchParams.get('difficulty') ?? null,
+    age: searchParams.get('age') ?? null,
+  };
+}

--- a/src/hooks/useInfiniteGames.ts
+++ b/src/hooks/useInfiniteGames.ts
@@ -1,0 +1,41 @@
+'use client';
+
+import { GameListResponse } from '@/types/game/game';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { useGameFilters } from './games/useGameFilters';
+
+export function useInfiniteGames() {
+  const filters = useGameFilters();
+  return useInfiniteQuery<GameListResponse>({
+    queryKey: ['games', filters],
+    queryFn: async ({ pageParam = 1 }) => {
+      const params = new URLSearchParams();
+
+      // react-query에서 관리하는 현재 page
+      params.set('page', String(pageParam));
+
+      // page_size 기본값: 없으면 12
+      params.set('page_size', String(filters.pageSize ?? 12));
+
+      // filters 나머지 항목 세팅
+      Object.entries(filters).forEach(([key, value]) => {
+        if (value !== undefined && value !== null && key !== 'page_size') {
+          params.set(key, String(value));
+        }
+      });
+
+      const res = await fetch(`/api/games?${params.toString()}`);
+      if (!res.ok) throw new Error('게임 데이터를 불러오지 못했습니다.');
+      return res.json();
+    },
+    getNextPageParam: (lastPage) => {
+      if (lastPage.next) {
+        const url = new URL(lastPage.next);
+        const nextPage = url.searchParams.get('page');
+        return nextPage ? Number(nextPage) : undefined;
+      }
+      return undefined;
+    },
+    initialPageParam: 1,
+  });
+}


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #102

## ✨ 작업 개요

* 게임 목록 페이지의 UX를 개선하기 위해 **필터 기능**, **무한 스크롤**, **로딩 스켈레톤 UI**를 통합적으로 구현하였습니다.
* 기존 정적 리스트 렌더링 방식에서 벗어나, 쿼리스트링 기반 필터 + `react-query` 기반 무한스크롤 + 유동적 로딩 표시 기능을 도입하였습니다.

## ✅ 작업 상세 내용

### 1. 게임 필터 로직 개선

* `useGameFilters` 훅 구현: `useSearchParams`를 활용해 URL 쿼리스트링을 파싱하도록 구성

  * 문자열 필드(`categories`, `genres`)는 배열로, 숫자 필드는 `Number()` 처리
  * 기본값 처리 및 `null` 방지 로직 포함

### 2. 게임 목록 무한 스크롤

* `useInfiniteGames` 훅 구현:

  * `useInfiniteQuery` 기반의 페이지 단위 게임 목록 요청
  * 필터 상태는 `useGameFilters`로 연동
* `GameListSection` 컴포넌트에 무한 스크롤 적용:

  * 초기 props(`gameListData`)는 react-query 캐시로 대체
  * 스크롤 하단 도달 시 `fetchNextPage()`로 다음 페이지 로딩

### 3. 스켈레톤 UI 도입

* `Skeleton` 공통 컴포넌트 생성
* 게임 목록 스켈레톤: `GameListSkeleton` 컴포넌트 구현

  * 컬럼 수, 이미지 비율, 개수 등 props로 유연하게 제어 가능
* 필터 사이드바 스켈레톤: `FilterSidebarSkeleton` 구현
* `GameListUI.tsx` 내 동적 import 컴포넌트에 `loading` 옵션으로 스켈레톤 적용

  * `BreadcrumbsSkeleton`도 함께 추가

### 4. 컴포넌트 경로 리팩토링

* `FilterSidebar`를 공통 컴포넌트 디렉토리에서 `games/_components`로 이동
* 관련 import 경로 절대 경로로 통일

## 스크린샷

![무한스크롤_스켈레톤](https://github.com/user-attachments/assets/bd973c1c-1167-4683-bfbf-6ea40aa6da71)

## 📌 기타 참고 사항

* 무한 스크롤 동작 확인은 필터 조작 및 스크롤 이벤트로 검증 가능
* 로딩 UX 개선을 통해 사용자 경험이 향상됨
* 향후 필터 적용 시 shallow routing과의 연동 여부도 고려 필요


