### PR TITLE
fix: 게임리스트 페이지 무한스크롤 수정 (#112)

### DIFF
--- a/src/app/games/_components/GameListSection.tsx
+++ b/src/app/games/_components/GameListSection.tsx
@@ -76,7 +76,6 @@ export default function GameListSection({
           <GameListSkeleton imageRatio="1:1" count={12} />
         </div>
       )}
-      {!hasNextPage && <p>더 이상 데이터가 없습니다.</p>}
     </section>
   );
 }

--- a/src/hooks/games/useGameFilters.ts
+++ b/src/hooks/games/useGameFilters.ts
@@ -6,8 +6,7 @@ export function useGameFilters() {
   const searchParams = useSearchParams();
   return {
     keyword: searchParams.get('keyword') ?? '',
-    page: Number(searchParams.get('page') ?? 1),
-    pageSize: Number(searchParams.get('page_size') ?? 12),
+    page_size: Number(searchParams.get('page_size') ?? 12),
     categories: searchParams.get('categories')?.split(',') ?? [],
     genres: searchParams.get('genres')?.split(',') ?? [],
     players: Number(searchParams.get('players') ?? 0),

--- a/src/hooks/useInfiniteGames.ts
+++ b/src/hooks/useInfiniteGames.ts
@@ -6,20 +6,26 @@ import { useGameFilters } from './games/useGameFilters';
 
 export function useInfiniteGames() {
   const filters = useGameFilters();
+
   return useInfiniteQuery<GameListResponse>({
     queryKey: ['games', filters],
     queryFn: async ({ pageParam = 1 }) => {
       const params = new URLSearchParams();
 
-      // react-query에서 관리하는 현재 page
+      // react-query에서 관리하는 현재 페이지
       params.set('page', String(pageParam));
+      params.set('page_size', '12');
 
-      // page_size 기본값: 없으면 12
-      params.set('page_size', String(filters.pageSize ?? 12));
-
-      // filters 나머지 항목 세팅
+      // filters 나머지 값만 세팅
       Object.entries(filters).forEach(([key, value]) => {
-        if (value !== undefined && value !== null && key !== 'page_size') {
+        const isFalsy =
+          value === undefined ||
+          value === null ||
+          value === '' ||
+          value === 0 ||
+          (Array.isArray(value) && value.length === 0);
+
+        if (!isFalsy) {
           params.set(key, String(value));
         }
       });
@@ -29,12 +35,9 @@ export function useInfiniteGames() {
       return res.json();
     },
     getNextPageParam: (lastPage) => {
-      if (lastPage.next) {
-        const url = new URL(lastPage.next);
-        const nextPage = url.searchParams.get('page');
-        return nextPage ? Number(nextPage) : undefined;
-      }
-      return undefined;
+      if (!lastPage.next) return undefined;
+      const url = new URL(lastPage.next);
+      return Number(url.searchParams.get('page'));
     },
     initialPageParam: 1,
   });


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #112

## ✨ 작업 개요
* 무한스크롤 구현후 페이지 변경안됨


## ✅ 작업 상세 내용
- filters 객체에서 쿼리 파라미터로 전달할 때, 불필요한 빈 값('', 0, 빈 배열 등) 제거 로직 추가
- page_size를 useGameFilters에서 pageSize → page_size로 변경하여 API와 키명 일치
- useInfiniteGames 내부에서 page_size는 고정값 '12'로 처리하여 혼동 제거
- getNextPageParam 로직 간결화

## 스크린샷

