### PR TITLE
feat: 비밀번호찾기api 연동구현 (#109)

### DIFF
--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -46,6 +46,23 @@ export type FindIdState = {
   email?: string;
 };
 
+export type PasswordResetState = {
+  success: boolean;
+  error: string | null;
+  message?: string;
+};
+
+export type PasswordResetVerifyState = {
+  success: boolean;
+  error: string | null;
+  reset_token?: string;
+};
+
+export type PasswordChangeState = {
+  success: boolean;
+  error: string | null;
+};
+
 async function setAuthCookies(accessToken: string, refreshToken: string) {
   const cookieStore = await cookies();
 
@@ -233,6 +250,105 @@ export async function findUserId(
     return {
       success: false,
       error: '아이디를 찾을 수 없습니다.',
+    };
+  }
+}
+
+export async function sendPasswordResetCode(
+  email: string
+): Promise<PasswordResetState> {
+  try {
+    const data = await fetcher<SendCodeApiResponse>(
+      '/auth/reset-password/request/',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          email,
+          purpose: 'restore', // purpose가 restore였죠!
+        }),
+      }
+    );
+
+    return {
+      success: true,
+      error: null,
+      message: data.message,
+    };
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      return { success: false, error: error.message };
+    }
+
+    return {
+      success: false,
+      error: '인증번호 전송 중 오류가 발생했습니다.',
+    };
+  }
+}
+
+// --- 비밀번호 재설정 인증번호 확인 Server Action ---
+export async function verifyPasswordResetCode(
+  email: string,
+  verificationCode: string
+): Promise<PasswordResetVerifyState> {
+  try {
+    const data = await fetcher<{ reset_token: string; message?: string }>(
+      '/auth/reset-password/verify/',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          email,
+          verification_code: verificationCode,
+        }),
+      }
+    );
+
+    return {
+      success: true,
+      error: null,
+      reset_token: data.reset_token,
+    };
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      return { success: false, error: error.message };
+    }
+
+    return {
+      success: false,
+      error: '인증번호 확인 중 오류가 발생했습니다.',
+    };
+  }
+}
+
+// --- 비밀번호 변경 Server Action ---
+export async function changePassword(
+  resetToken: string,
+  newPassword: string
+): Promise<PasswordChangeState> {
+  try {
+    const data = await fetcher<{ message: string }>(
+      '/auth/reset-password/finalize/',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          reset_token: resetToken,
+          new_password: newPassword,
+        }),
+      }
+    );
+
+    return {
+      success: true,
+      error: null,
+    };
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      return { success: false, error: error.message };
+    }
+
+    return {
+      success: false,
+      error: '비밀번호 변경 중 오류가 발생했습니다.',
     };
   }
 }

--- a/src/app/auth/find-password/page.tsx
+++ b/src/app/auth/find-password/page.tsx
@@ -1,333 +1,68 @@
 'use client';
 
 import { useState } from 'react';
-import { useForm } from 'react-hook-form';
-import { useRouter } from 'next/navigation';
-import Link from 'next/link';
 
-import Button from '@/components/common/Button';
-import Input from '@/components/common/Input';
 import Grid from '@/components/layout/Grid';
 import { Toast } from '@/components/common/Toast';
-import { useToast } from '@/hooks/useToast';
-import { useEmailValidation } from '@/hooks/useEmailValidation';
+import { usePasswordReset } from '@/hooks/usePasswordReset';
 
-const FORM_LAYOUT = {
-  COLUMNS: 'grid-cols-[2fr_1fr]',
-};
+import FindPasswordForm from '@/components/auth/FindPasswordForm';
+import PasswordChangeSection from '@/components/auth/PasswordChangeSection';
 
-const PLACEHOLDER = {
-  NAME: '이름 입력',
-  EMAIL: '이메일주소',
-  CODE: '인증번호 입력',
-};
-
-const PASSWORD_REGEX =
-  /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/;
-
-interface FormData {
-  name: string;
+interface PasswordResetData {
   email: string;
-  verificationCode?: string;
+  verificationCode: string;
+  resetToken: string;
 }
-
-interface PasswordChangeFormData {
-  newPassword: string;
-  confirmPassword: string;
-}
-
-const PasswordChangeSection = () => {
-  const [submitError, setSubmitError] = useState('');
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const router = useRouter();
-  const { success, error } = useToast();
-
-  const {
-    register,
-    handleSubmit,
-    watch,
-    formState: { errors, isValid },
-  } = useForm<PasswordChangeFormData>({
-    mode: 'onChange',
-  });
-
-  const newPassword = watch('newPassword');
-  const confirmPassword = watch('confirmPassword');
-
-  const onSubmit = async (data: PasswordChangeFormData) => {
-    setSubmitError('');
-    setIsSubmitting(true);
-
-    try {
-      const _passwordData = {
-        newPassword: data.newPassword,
-        confirmPassword: data.confirmPassword,
-      };
-
-      // TODO: 실제 API 호출로 대체
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-
-      success('비밀번호가 변경되었습니다.');
-      router.push('/auth/login');
-    } catch (e) {
-      error('비밀번호 변경에 실패했습니다. 다시 시도해주세요.');
-      setSubmitError('비밀번호 변경에 실패했습니다. 다시 시도해주세요.');
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const isPasswordValid = PASSWORD_REGEX.test(newPassword || '');
-  const isPasswordMatch = newPassword === confirmPassword;
-
-  return (
-    <>
-      <header className="mb-8 text-center">
-        <h1 className="text-2xl leading-[49px] font-extrabold text-gray-900">
-          비밀번호 변경
-        </h1>
-        <p className="mt-2 text-sm text-gray-600">
-          새로운 비밀번호를 변경해주세요.
-        </p>
-      </header>
-
-      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
-        <Input
-          type="password"
-          placeholder="8~15자의 영문 대소문자, 숫자, 특수문자 포함"
-          label="새 비밀번호"
-          inputSize="md"
-          error={
-            errors.newPassword?.message ||
-            (newPassword && !isPasswordValid
-              ? '영어대소문자 숫자 특수문자를 포함한 8자리 이상으로 입력해주세요'
-              : false)
-          }
-          success={
-            newPassword && isPasswordValid && !errors.newPassword
-              ? '비밀번호가 충족되었습니다'
-              : false
-          }
-          required
-          {...register('newPassword', {
-            required: '새 비밀번호를 입력해주세요',
-            minLength: {
-              value: 8,
-              message: '비밀번호는 8자 이상이어야 합니다',
-            },
-            maxLength: {
-              value: 15,
-              message: '비밀번호는 15자 이하여야 합니다',
-            },
-            pattern: {
-              value: PASSWORD_REGEX,
-              message: '영문 대소문자, 숫자, 특수문자를 포함해야 합니다',
-            },
-          })}
-        />
-
-        <Input
-          type="password"
-          placeholder="비밀번호를 다시 입력해주세요"
-          label="새 비밀번호 확인"
-          inputSize="md"
-          error={
-            errors.confirmPassword?.message ||
-            (confirmPassword && !isPasswordMatch
-              ? '비밀번호를 다시 확인해주세요'
-              : false)
-          }
-          success={
-            confirmPassword && isPasswordMatch && !errors.confirmPassword
-              ? '비밀번호가 확인되었습니다'
-              : false
-          }
-          required
-          {...register('confirmPassword', {
-            required: '비밀번호 확인을 입력해주세요',
-            validate: (value) =>
-              value === newPassword || '비밀번호가 일치하지 않습니다',
-          })}
-        />
-
-        {submitError && (
-          <div className="text-center text-sm text-red-400">{submitError}</div>
-        )}
-
-        <Button
-          type="submit"
-          variant="primary"
-          size="lg"
-          className={`w-full text-white ${
-            isValid && isPasswordValid && isPasswordMatch
-              ? 'bg-primary-500 hover:bg-primary-600 cursor-pointer'
-              : 'cursor-not-allowed bg-gray-300'
-          }`}
-          disabled={
-            !isValid || !isPasswordValid || !isPasswordMatch || isSubmitting
-          }
-        >
-          {isSubmitting ? '처리 중...' : '확인'}
-        </Button>
-      </form>
-    </>
-  );
-};
 
 export default function FindPasswordPage() {
-  const [isPasswordChangeVisible, setIsPasswordChangeVisible] = useState(false);
-  const [isCodeSent, setCodeSent] = useState(false);
-  const [isVerified, setVerified] = useState(false);
-
-  const { emailRules } = useEmailValidation();
-  const { toasts, success, error } = useToast();
+  const [step, setStep] = useState<'form' | 'change'>('form');
+  const [passwordResetData, setPasswordResetData] = useState<PasswordResetData>(
+    {
+      email: '',
+      verificationCode: '',
+      resetToken: '',
+    }
+  );
 
   const {
-    register,
-    handleSubmit,
-    watch,
-    formState: { errors },
-  } = useForm<FormData>();
+    isCodeSent,
+    isVerified,
+    resetToken,
+    isLoading,
+    toasts,
+    sendCode,
+    verifyCode,
+    changeUserPassword,
+  } = usePasswordReset();
 
-  const name = watch('name');
-  const email = watch('email');
-  const verificationCode = watch('verificationCode');
-
-  const sendCode = () => {
-    if (!name?.trim()) return error('이름을 입력해주세요');
-    if (!emailRules.pattern.value.test(email || '')) {
-      return error(emailRules.pattern.message);
-    }
-
-    success('인증번호가 전송되었습니다!');
-    setCodeSent(true);
-    setVerified(false);
-  };
-
-  const verifyCode = () => {
-    if (!verificationCode?.trim()) return error('인증번호를 입력해주세요');
-    success('인증번호가 확인되었습니다!');
-    setVerified(true);
-  };
-
-  const onSubmit = (data: FormData) => {
-    setIsPasswordChangeVisible(true);
+  const handleFormComplete = (data: PasswordResetData) => {
+    setPasswordResetData(data);
+    setStep('change');
   };
 
   return (
     <>
       <Toast toasts={toasts} />
+
       <div className="inner">
         <Grid className="pt-20 pb-30">
           <Grid.Item span="col-span-4 sm:col-start-3 sm:col-span-4 md:col-start-5 md:col-span-4">
-            {isPasswordChangeVisible ? (
-              <PasswordChangeSection />
+            {step === 'change' ? (
+              <PasswordChangeSection
+                isLoading={isLoading}
+                onChangePassword={changeUserPassword}
+              />
             ) : (
-              <>
-                <header className="text-center">
-                  <h1 className="text-2xl leading-[49px] font-extrabold text-gray-900">
-                    비밀번호 찾기
-                  </h1>
-                </header>
-                <form onSubmit={handleSubmit(onSubmit)} className="pt-8">
-                  <div className="mb-6">
-                    <label className="mb-1 block text-sm font-medium text-gray-700">
-                      이름 <span className="text-primary-500">*</span>
-                    </label>
-                    <Input
-                      type="text"
-                      placeholder={PLACEHOLDER.NAME}
-                      inputSize="md"
-                      variant={errors.name ? 'error' : 'default'}
-                      {...register('name', { required: '이름을 입력해주세요' })}
-                      required
-                    />
-                  </div>
-
-                  <div className="mb-6">
-                    <label className="mb-1 block text-sm font-medium text-gray-700">
-                      이메일주소 <span className="text-primary-500">*</span>
-                    </label>
-                    <div
-                      className={`grid w-full ${FORM_LAYOUT.COLUMNS} gap-x-2 gap-y-3`}
-                    >
-                      <div>
-                        <Input
-                          type="email"
-                          placeholder={PLACEHOLDER.EMAIL}
-                          inputSize="md"
-                          variant={errors.email ? 'error' : 'default'}
-                          {...register('email', emailRules)}
-                          required
-                        />
-                      </div>
-                      <div className="flex items-start">
-                        <Button
-                          type="button"
-                          variant="secondary"
-                          size="sm"
-                          className="h-fit w-full font-semibold whitespace-nowrap"
-                          onClick={sendCode}
-                        >
-                          인증번호 전송
-                        </Button>
-                      </div>
-                    </div>
-
-                    {isCodeSent && (
-                      <div
-                        className={`mt-3 grid w-full ${FORM_LAYOUT.COLUMNS} gap-x-2 gap-y-3`}
-                      >
-                        <div>
-                          <Input
-                            type="text"
-                            placeholder={PLACEHOLDER.CODE}
-                            inputSize="md"
-                            variant={
-                              errors.verificationCode ? 'error' : 'default'
-                            }
-                            {...register('verificationCode', {
-                              required: '인증번호를 입력해주세요',
-                            })}
-                          />
-                        </div>
-                        <div className="flex items-start">
-                          <Button
-                            type="button"
-                            variant="secondary"
-                            size="sm"
-                            className="h-fit w-full font-semibold whitespace-nowrap"
-                            onClick={verifyCode}
-                          >
-                            인증번호 확인
-                          </Button>
-                        </div>
-                      </div>
-                    )}
-                  </div>
-
-                  <Button
-                    type="submit"
-                    variant="primary"
-                    size="lg"
-                    className={`bg-primary-500 hover:bg-primary-600 w-full text-white ${
-                      !isVerified ? 'cursor-not-allowed opacity-50' : ''
-                    }`}
-                    disabled={!isVerified}
-                  >
-                    확인
-                  </Button>
-                </form>
-
-                <div className="mt-6 text-center">
-                  <Link
-                    href="/auth/find-id"
-                    className="hover:text-primary-500 text-sm text-gray-600"
-                  >
-                    아이디를 잊으셨나요?
-                  </Link>
-                </div>
-              </>
+              <FindPasswordForm
+                isCodeSent={isCodeSent}
+                isVerified={isVerified}
+                isLoading={isLoading}
+                resetToken={resetToken}
+                onSendCode={sendCode}
+                onVerifyCode={verifyCode}
+                onComplete={handleFormComplete}
+              />
             )}
           </Grid.Item>
         </Grid>

--- a/src/components/auth/FindPasswordForm.tsx
+++ b/src/components/auth/FindPasswordForm.tsx
@@ -1,0 +1,186 @@
+'use client';
+
+import { useForm } from 'react-hook-form';
+import Link from 'next/link';
+
+import Button from '@/components/common/Button';
+import Input from '@/components/common/Input';
+
+const FORM_LAYOUT = {
+  COLUMNS: 'grid-cols-[2fr_1fr]',
+} as const;
+
+const PLACEHOLDER = {
+  NAME: '이름 입력',
+  EMAIL: '이메일주소',
+  CODE: '인증번호 입력',
+} as const;
+
+interface FormData {
+  name: string;
+  email: string;
+  verificationCode?: string;
+}
+
+interface FindPasswordFormProps {
+  isCodeSent: boolean;
+  isVerified: boolean;
+  isLoading: boolean;
+  resetToken: string;
+  onSendCode: (email: string, name: string) => Promise<boolean>;
+  onVerifyCode: (email: string, verificationCode: string) => Promise<boolean>;
+  onComplete: (data: {
+    email: string;
+    verificationCode: string;
+    resetToken: string;
+  }) => void;
+}
+
+const FindPasswordForm = ({
+  isCodeSent,
+  isVerified,
+  isLoading,
+  resetToken,
+  onSendCode,
+  onVerifyCode,
+  onComplete,
+}: FindPasswordFormProps) => {
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors },
+  } = useForm<FormData>();
+
+  const name = watch('name');
+  const email = watch('email');
+  const verificationCode = watch('verificationCode');
+
+  const handleSendCode = async () => {
+    await onSendCode(email, name);
+  };
+
+  const handleVerifyCode = async () => {
+    await onVerifyCode(email, verificationCode || '');
+  };
+
+  const onSubmit = () => {
+    onComplete({
+      email,
+      verificationCode: verificationCode || '',
+      resetToken,
+    });
+  };
+
+  return (
+    <>
+      <header className="text-center">
+        <h1 className="text-2xl leading-[49px] font-extrabold text-gray-900">
+          비밀번호 찾기
+        </h1>
+      </header>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="pt-8">
+        <div className="mb-6">
+          <label className="mb-1 block text-sm font-medium text-gray-700">
+            이름 <span className="text-primary-500">*</span>
+          </label>
+          <Input
+            type="text"
+            placeholder={PLACEHOLDER.NAME}
+            inputSize="md"
+            variant={errors.name ? 'error' : 'default'}
+            disabled={isLoading}
+            {...register('name', { required: '이름을 입력해주세요' })}
+            required
+          />
+        </div>
+
+        <div className="mb-6">
+          <label className="mb-1 block text-sm font-medium text-gray-700">
+            이메일주소 <span className="text-primary-500">*</span>
+          </label>
+          <div className={`grid w-full ${FORM_LAYOUT.COLUMNS} gap-x-2 gap-y-3`}>
+            <Input
+              type="email"
+              placeholder={PLACEHOLDER.EMAIL}
+              inputSize="md"
+              variant={errors.email ? 'error' : 'default'}
+              disabled={isLoading}
+              {...register('email', {
+                required: '이메일을 입력해주세요',
+                pattern: {
+                  value: /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i,
+                  message: '올바른 이메일 형식을 입력해주세요',
+                },
+              })}
+              required
+            />
+            <Button
+              type="button"
+              variant="secondary"
+              size="sm"
+              className="h-fit w-full font-semibold whitespace-nowrap"
+              disabled={isLoading || !email || !name}
+              onClick={handleSendCode}
+            >
+              {isLoading ? '전송 중...' : '인증번호 전송'}
+            </Button>
+          </div>
+
+          {isCodeSent && (
+            <div
+              className={`mt-3 grid w-full ${FORM_LAYOUT.COLUMNS} gap-x-2 gap-y-3`}
+            >
+              <Input
+                type="text"
+                placeholder={PLACEHOLDER.CODE}
+                inputSize="md"
+                variant={errors.verificationCode ? 'error' : 'default'}
+                disabled={isLoading}
+                {...register('verificationCode', {
+                  required: '인증번호를 입력해주세요',
+                })}
+              />
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                className="h-fit w-full font-semibold whitespace-nowrap"
+                disabled={isLoading || !verificationCode}
+                onClick={handleVerifyCode}
+              >
+                {isLoading ? '확인 중...' : '인증번호 확인'}
+              </Button>
+            </div>
+          )}
+        </div>
+
+        <Button
+          type="submit"
+          variant="primary"
+          size="lg"
+          className={`w-full text-white ${
+            isVerified
+              ? 'bg-primary-500 hover:bg-primary-600 cursor-pointer'
+              : 'cursor-not-allowed bg-gray-300'
+          }`}
+          disabled={!isVerified || isLoading}
+        >
+          {isLoading ? '처리 중...' : '확인'}
+        </Button>
+      </form>
+
+      <div className="mt-6 text-center">
+        <Link
+          href="/auth/find-id"
+          className="hover:text-primary-500 text-sm text-gray-600"
+        >
+          아이디를 잊으셨나요?
+        </Link>
+      </div>
+    </>
+  );
+};
+
+export default FindPasswordForm;

--- a/src/components/auth/PasswordChangeSection.tsx
+++ b/src/components/auth/PasswordChangeSection.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useRouter } from 'next/navigation';
+
+import Button from '@/components/common/Button';
+import Input from '@/components/common/Input';
+
+const PASSWORD_REGEX =
+  /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/;
+
+interface PasswordChangeFormData {
+  newPassword: string;
+  confirmPassword: string;
+}
+
+interface PasswordChangeSectionProps {
+  isLoading: boolean;
+  onChangePassword: (newPassword: string) => Promise<boolean>;
+}
+
+const PasswordChangeSection = ({
+  isLoading,
+  onChangePassword,
+}: PasswordChangeSectionProps) => {
+  const [submitError, setSubmitError] = useState('');
+  const router = useRouter();
+
+  const {
+    register,
+    handleSubmit,
+    watch,
+    formState: { errors, isValid },
+  } = useForm<PasswordChangeFormData>({
+    mode: 'onChange',
+  });
+
+  const newPassword = watch('newPassword');
+  const confirmPassword = watch('confirmPassword');
+
+  const onSubmit = async (data: PasswordChangeFormData) => {
+    setSubmitError('');
+
+    const success = await onChangePassword(data.newPassword);
+
+    if (success) {
+      router.push('/auth/login');
+    } else {
+      setSubmitError('비밀번호 변경에 실패했습니다. 다시 시도해주세요.');
+    }
+  };
+
+  const isPasswordValid = PASSWORD_REGEX.test(newPassword || '');
+  const isPasswordMatch = newPassword === confirmPassword;
+  const isFormValid = isValid && isPasswordValid && isPasswordMatch;
+
+  return (
+    <>
+      <header className="mb-8 text-center">
+        <h1 className="text-2xl leading-[49px] font-extrabold text-gray-900">
+          비밀번호 변경
+        </h1>
+        <p className="mt-2 text-sm text-gray-600">
+          새로운 비밀번호를 입력해주세요.
+        </p>
+      </header>
+
+      <form onSubmit={handleSubmit(onSubmit)} className="space-y-6">
+        <Input
+          type="password"
+          placeholder="8~15자의 영문 대소문자, 숫자, 특수문자 포함"
+          label="새 비밀번호"
+          inputSize="md"
+          disabled={isLoading}
+          error={
+            errors.newPassword?.message ||
+            (newPassword && !isPasswordValid
+              ? '영어대소문자 숫자 특수문자를 포함한 8자리 이상으로 입력해주세요'
+              : false)
+          }
+          success={
+            newPassword && isPasswordValid && !errors.newPassword
+              ? '비밀번호가 충족되었습니다'
+              : false
+          }
+          required
+          {...register('newPassword', {
+            required: '새 비밀번호를 입력해주세요',
+            minLength: {
+              value: 8,
+              message: '비밀번호는 8자 이상이어야 합니다',
+            },
+            maxLength: {
+              value: 15,
+              message: '비밀번호는 15자 이하여야 합니다',
+            },
+            pattern: {
+              value: PASSWORD_REGEX,
+              message: '영문 대소문자, 숫자, 특수문자를 포함해야 합니다',
+            },
+          })}
+        />
+
+        <Input
+          type="password"
+          placeholder="비밀번호를 다시 입력해주세요"
+          label="새 비밀번호 확인"
+          inputSize="md"
+          disabled={isLoading}
+          error={
+            errors.confirmPassword?.message ||
+            (confirmPassword && !isPasswordMatch
+              ? '비밀번호를 다시 확인해주세요'
+              : false)
+          }
+          success={
+            confirmPassword && isPasswordMatch && !errors.confirmPassword
+              ? '비밀번호가 확인되었습니다'
+              : false
+          }
+          required
+          {...register('confirmPassword', {
+            required: '비밀번호 확인을 입력해주세요',
+            validate: (value) =>
+              value === newPassword || '비밀번호가 일치하지 않습니다',
+          })}
+        />
+
+        {submitError && (
+          <div className="text-center text-sm text-red-400">{submitError}</div>
+        )}
+
+        <Button
+          type="submit"
+          variant="primary"
+          size="lg"
+          className={`w-full text-white ${
+            isFormValid && !isLoading
+              ? 'bg-primary-500 hover:bg-primary-600 cursor-pointer'
+              : 'cursor-not-allowed bg-gray-300'
+          }`}
+          disabled={!isFormValid || isLoading}
+        >
+          {isLoading ? '변경 중...' : '비밀번호 변경'}
+        </Button>
+      </form>
+    </>
+  );
+};
+
+export default PasswordChangeSection;

--- a/src/hooks/usePasswordReset.ts
+++ b/src/hooks/usePasswordReset.ts
@@ -1,0 +1,118 @@
+import { useState } from 'react';
+import { useToast } from '@/hooks/useToast';
+import { useEmailValidation } from '@/hooks/useEmailValidation';
+import {
+  sendPasswordResetCode,
+  verifyPasswordResetCode,
+  changePassword,
+} from '@/actions/auth';
+
+export const usePasswordReset = () => {
+  const [isCodeSent, setIsCodeSent] = useState(false);
+  const [isVerified, setIsVerified] = useState(false);
+  const [resetToken, setResetToken] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const { toasts, success, error } = useToast();
+  const { emailRules } = useEmailValidation();
+
+  const sendCode = async (email: string, name: string) => {
+    if (!name?.trim()) {
+      error('이름을 입력해주세요');
+      return false;
+    }
+
+    if (!emailRules.pattern.value.test(email)) {
+      error(emailRules.pattern.message);
+      return false;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const result = await sendPasswordResetCode(email);
+
+      if (result.success) {
+        success(result.message || '인증번호가 전송되었습니다!');
+        setIsCodeSent(true);
+        setIsVerified(false);
+        return true;
+      } else {
+        error(result.error || '인증번호 전송에 실패했습니다.');
+        return false;
+      }
+    } catch (err) {
+      error('인증번호 전송 중 오류가 발생했습니다.');
+      return false;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const verifyCode = async (email: string, verificationCode: string) => {
+    if (!verificationCode?.trim()) {
+      error('인증번호를 입력해주세요');
+      return false;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const result = await verifyPasswordResetCode(email, verificationCode);
+
+      if (result.success) {
+        if (result.reset_token) {
+          setResetToken(result.reset_token);
+        }
+        success('인증번호가 확인되었습니다!');
+        setIsVerified(true);
+        return true;
+      } else {
+        error(result.error || '인증번호가 올바르지 않습니다.');
+        return false;
+      }
+    } catch (err) {
+      error('인증번호 확인 중 오류가 발생했습니다.');
+      return false;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const changeUserPassword = async (newPassword: string) => {
+    if (!resetToken) {
+      error('인증이 완료되지 않았습니다. 인증번호를 먼저 확인해주세요.');
+      return false;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const result = await changePassword(resetToken, newPassword);
+
+      if (result.success) {
+        success('비밀번호가 변경되었습니다.');
+        return true;
+      } else {
+        error(result.error || '비밀번호 변경에 실패했습니다.');
+        return false;
+      }
+    } catch (err) {
+      error('비밀번호 변경 중 오류가 발생했습니다.');
+      return false;
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return {
+    isCodeSent,
+    isVerified,
+    resetToken,
+    isLoading,
+    toasts,
+    sendCode,
+    verifyCode,
+    changeUserPassword,
+  };
+};


### PR DESCRIPTION
## 🔗 관련 이슈
- Closes #109 

## ✨ 작업 개요
비밀번호 찾기 페이지를 컴포넌트 기반 아키텍처로 리팩토링하고, 실제 서버 액션을 연동하여 완전한 비밀번호 재설정 기능을 구현했습니다.

## ✅ 작업 상세 내용
- **단일 진실 공급원 패턴** 적용: `usePasswordReset` 훅을 메인 페이지에서만 호출
- **Props Drilling 패턴** 도입: 자식 컴포넌트들은 훅을 직접 import하지 않고 props로만 데이터 수신
- **컴포넌트 분리**: 관심사 분리를 통한 유지보수성 향상

