### PR TITLE
feat: 메인페이지 api 연동 및 mock 데이터 제거

### DIFF
--- a/src/app/api/recommended-games/route.ts
+++ b/src/app/api/recommended-games/route.ts
@@ -1,0 +1,19 @@
+import { cookies } from 'next/headers';
+import { fetcher } from '@/lib/fetcher';
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  try {
+    const jar = await cookies();
+    const accessToken = jar.get('access_token')?.value;
+
+    if (!accessToken) {
+      return NextResponse.json(null);
+    }
+
+    const data = await fetcher('/recommendations', {}, accessToken);
+    return NextResponse.json(data);
+  } catch (error) {
+    return NextResponse.json(null);
+  }
+}

--- a/src/app/api/user/route.ts
+++ b/src/app/api/user/route.ts
@@ -1,0 +1,11 @@
+import { getUser } from '@/lib/auth';
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  try {
+    const user = await getUser();
+    return NextResponse.json(user);
+  } catch (error) {
+    return NextResponse.json(null);
+  }
+}

--- a/src/components/main/GameThemeCuration.tsx
+++ b/src/components/main/GameThemeCuration.tsx
@@ -6,25 +6,25 @@ const contents = [
     title: '입문자 추천',
     description: '처음 시작하기 좋은 쉽고 재미있는 게임들',
     imageUrl: '/images/main/img_curation01.png',
-    link: '/games?theme=beginner',
+    link: '/games?difficulty=쉬움',
   },
   {
     title: '2인 전용',
     description: '연인, 친구와 둘이서 즐기기 좋은 게임',
     imageUrl: '/images/main/img_curation02.png',
-    link: '/games?theme=family',
+    link: '/games?players=2',
   },
   {
     title: '파티게임',
     description: '여러명이 함께 웃으며 즐길수 있는 게임',
     imageUrl: '/images/main/img_curation03.png',
-    link: '/games?theme=family',
+    link: '/games?categories=파티게임',
   },
   {
     title: '전략가 추천',
     description: '깊이 있는 전략과 사고가 필요한 게임',
     imageUrl: '/images/main/img_curation04.png',
-    link: '/games?theme=family',
+    link: '/games?categories=전략게임',
   },
 ];
 

--- a/src/components/main/MainBannerCarousel.tsx
+++ b/src/components/main/MainBannerCarousel.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { mainBannerList } from '@/assets/mocks/mainBannerList';
+import { useEffect, useState } from 'react';
 import Button from '@/components/common/Button';
 import {
   RiArrowLeftSLine,
@@ -14,7 +14,35 @@ import 'swiper/css/pagination';
 import { Autoplay, Navigation } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
 
+interface BannerGame {
+  game_id: number;
+  title: string;
+  thumbnail_url: string;
+  genre: string;
+  category: string;
+}
+
 export default function MainBannerCarousel() {
+  const [bannerGames, setBannerGames] = useState<BannerGame[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/games?page=1&page_size=10')
+      .then((res) => res.json())
+      .then((data) => {
+        setBannerGames(data.results || []);
+        setLoading(false);
+      })
+      .catch(() => {
+        setBannerGames([]);
+        setLoading(false);
+      });
+  }, []);
+
+  if (loading) {
+    return <div className="relative mt-2 mb-16 h-96">로딩중...</div>;
+  }
+
   return (
     <div className="relative mt-2 mb-16">
       <div className="absolute top-0 z-10 hidden aspect-square overflow-hidden rounded-xl p-8 md:block md:w-[calc(50%_-_4px)] lg:w-[calc(33.3333%_-_5.3333px)] xl:right-[calc(50%+4px)] xl:w-[calc(25%_-_6px)]">
@@ -50,6 +78,8 @@ export default function MainBannerCarousel() {
           </Button>
         </Link>
       </div>
+
+      {/* 게임 슬라이더 */}
       <div className="overflow-hidden">
         <Swiper
           slidesPerView={1}
@@ -66,26 +96,20 @@ export default function MainBannerCarousel() {
             prevEl: '.main-button-prev',
           }}
           breakpoints={{
-            768: {
-              slidesPerView: 2,
-            },
-            1024: {
-              slidesPerView: 3,
-            },
-            1280: {
-              slidesPerView: 4,
-            },
+            768: { slidesPerView: 2 },
+            1024: { slidesPerView: 3 },
+            1280: { slidesPerView: 4 },
           }}
         >
-          {mainBannerList.map((banner, index) => (
-            <SwiperSlide key={index}>
+          {bannerGames.map((game, index) => (
+            <SwiperSlide key={game.game_id}>
               <Link
-                href={`/games/${banner.gameId}`}
+                href={`/games/${game.game_id}`}
                 className="group relative block aspect-square w-full overflow-hidden rounded-xl"
               >
                 <Image
-                  src={banner.src}
-                  alt={banner.title}
+                  src={game.thumbnail_url}
+                  alt={game.title}
                   width={768}
                   height={360}
                   className="absolute inset-0 h-full w-full object-cover"
@@ -93,24 +117,25 @@ export default function MainBannerCarousel() {
                 />
                 <div className="absolute right-0 bottom-0 left-0 bg-gradient-to-t from-black to-transparent px-6 py-8 transition-all group-hover:h-full group-hover:from-[#00000087] group-hover:to-[#00000087]">
                   <h3 className="line-clamp-2 text-2xl font-bold text-white">
-                    {banner.title}
+                    {game.title}
                   </h3>
                   <p className="mt-3 line-clamp-2 text-sm text-gray-200">
-                    {banner.description}
+                    {game.genre} · {game.category}
                   </p>
                 </div>
               </Link>
             </SwiperSlide>
           ))}
-          <div className="pointer-events-none absolute top-1/2 left-1/2 z-20 flex w-full -translate-x-1/2 -translate-y-1/2 transform justify-between px-6 xl:w-[calc(50%+10rem)]">
-            <div className="main-button-prev">
-              <RiArrowLeftSLine className="h-10 w-10" />
-            </div>
-            <div className="main-button-next">
-              <RiArrowRightSLine className="h-10 w-10" />
-            </div>
-          </div>
         </Swiper>
+
+        <div className="pointer-events-none absolute top-1/2 left-1/2 z-20 flex w-full -translate-x-1/2 -translate-y-1/2 transform justify-between px-6 xl:w-[calc(50%+10rem)]">
+          <div className="main-button-prev pointer-events-auto cursor-pointer">
+            <RiArrowLeftSLine className="h-10 w-10 text-white" />
+          </div>
+          <div className="main-button-next pointer-events-auto cursor-pointer">
+            <RiArrowRightSLine className="h-10 w-10 text-white" />
+          </div>
+        </div>
       </div>
     </div>
   );

--- a/src/components/main/NewAndHotGameSection.tsx
+++ b/src/components/main/NewAndHotGameSection.tsx
@@ -1,26 +1,90 @@
-import { gameListData } from '@/assets/mocks/gameListData';
 import { RiArrowRightLine } from '@remixicon/react';
 import Link from 'next/link';
 import RankItemList from './RankItemList';
+import { fetcher } from '@/lib/fetcher';
+import { GameListItem } from '@/types/game/game';
 
-export default function NewAndHotGameSection() {
-  const games = gameListData.games.slice(0, 3);
-  return (
-    <div className="inner">
-      <h2 className="mb-8 flex items-center justify-between text-2xl font-bold md:text-3xl">
-        보드큐 랭킹
-        <Link
-          href="/ranking"
-          className="group flex items-center gap-1 p-1 text-sm text-gray-900 hover:underline"
-        >
-          전체보기
-          <RiArrowRightLine className="w-4 transition-transform group-hover:translate-x-1" />
-        </Link>
-      </h2>
-      <div className="grid grid-cols-1 gap-15 md:grid-cols-2 md:gap-6">
-        <RankItemList games={games} title="전체" />
-        <RankItemList games={games} title="평점순" />
+interface RankingApiResponse {
+  top_by_like: Array<{
+    game_id: number;
+    thumbnail_url: string;
+    title: string;
+    description: string | null;
+    like_count: number;
+    average_rating: number;
+    genre: string;
+    category: string;
+    difficulty: string;
+  }>;
+  top_by_rating: Array<{
+    game_id: number;
+    thumbnail_url: string;
+    title: string;
+    description: string | null;
+    like_count: number;
+    average_rating: number;
+    genre: string;
+    category: string;
+    difficulty: string;
+  }>;
+}
+
+export default async function NewAndHotGameSection() {
+  try {
+    const response = await fetcher<RankingApiResponse>('/games/ranking/');
+
+    // API 데이터를 GameListItem 형식으로 변환
+    const popularGames: (GameListItem & { description?: string })[] = (
+      response.top_by_like || []
+    ).map((game) => ({
+      game_id: game.game_id,
+      title: game.title,
+      thumbnail_url: game.thumbnail_url,
+      difficulty: game.difficulty,
+      like_count: game.like_count,
+      average_rating: game.average_rating,
+      reviews_count: 0, // API에 없으니 기본값
+      genre: game.genre,
+      category: game.category,
+      is_liked: false, // API에 없으니 기본값
+      description: game.description || undefined,
+    }));
+
+    const ratingGames: (GameListItem & { description?: string })[] = (
+      response.top_by_rating || []
+    ).map((game) => ({
+      game_id: game.game_id,
+      title: game.title,
+      thumbnail_url: game.thumbnail_url,
+      difficulty: game.difficulty,
+      like_count: game.like_count,
+      average_rating: game.average_rating,
+      reviews_count: 0,
+      genre: game.genre,
+      category: game.category,
+      is_liked: false,
+      description: game.description || undefined,
+    }));
+
+    return (
+      <div className="inner">
+        <h2 className="mb-8 flex items-center justify-between text-2xl font-bold md:text-3xl">
+          보드큐 랭킹
+          <Link
+            href="/ranking"
+            className="group flex items-center gap-1 p-1 text-sm text-gray-900 hover:underline"
+          >
+            전체보기
+            <RiArrowRightLine className="w-4 transition-transform group-hover:translate-x-1" />
+          </Link>
+        </h2>
+        <div className="grid grid-cols-1 gap-15 md:grid-cols-2 md:gap-6">
+          <RankItemList games={popularGames} title="전체" />
+          <RankItemList games={ratingGames} title="평점순" />
+        </div>
       </div>
-    </div>
-  );
+    );
+  } catch (error) {
+    return <div className="inner">랭킹 데이터를 불러오는데 실패했습니다.</div>;
+  }
 }

--- a/src/components/main/PreferenceSurveyCTA.tsx
+++ b/src/components/main/PreferenceSurveyCTA.tsx
@@ -3,7 +3,7 @@ import Link from 'next/link';
 
 export default function PreferenceSurveyCTA() {
   return (
-    <Link href={'/preference'} className="block w-full">
+    <Link href={'/auth/login'} className="block w-full">
       <section className="border-primary-300 relative flex items-center justify-between overflow-hidden rounded-2xl border bg-gradient-to-r from-[#FFE6FA] via-[#A1DCE4] to-[#D7FFAC] p-6 text-sm">
         <div>
           <p className="mb-1 text-lg font-semibold">

--- a/src/components/main/RankItem.tsx
+++ b/src/components/main/RankItem.tsx
@@ -40,20 +40,20 @@ export default function RankItem({ game, index }: RankItemProps) {
       <div className="flex flex-1 flex-col justify-center gap-2">
         <h3 className="text-base font-bold">{game.title}</h3>
         <div className="flex gap-4">
-          {game.like_count && (
+          {game.like_count != null ? (
             <div className="flex items-center gap-2">
               <RiHeartFill className="h-4 w-4 text-gray-300" />
               <span className="text-xs">{game.like_count ?? 0}</span>
             </div>
-          )}
-          {game.average_rating && (
+          ) : null}
+          {game.average_rating != null ? (
             <div className="flex items-center gap-2">
               <RiStarFill className="h-4 w-4 text-gray-300" />
               <span className="text-xs">
                 {game.average_rating?.toFixed(1) ?? '-'}
               </span>
             </div>
-          )}
+          ) : null}
         </div>
         <div className="mt-1 flex flex-wrap gap-1 text-xs text-white">
           <GameTags

--- a/src/components/main/RecommendedGameSection.tsx
+++ b/src/components/main/RecommendedGameSection.tsx
@@ -1,10 +1,39 @@
-import { gameListData } from '@/assets/mocks/gameListData';
-import { userProfile } from '@/assets/mocks/userProfile';
+'use client';
+
+import { useEffect, useState } from 'react';
 import PreferenceSurveyCTA from '@/components/main/PreferenceSurveyCTA';
 import RecommendedGameListWrapper from '@/components/main/RecommendedGameListWrapper';
 
+interface User {
+  nickname: string;
+  name: string;
+}
+
 export default function RecommendedGameSection() {
-  const user = userProfile;
+  const [user, setUser] = useState<User | null>(null);
+  const [games, setGames] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    Promise.all([fetch('/api/user'), fetch('/api/recommended-games')])
+      .then(([userRes, gamesRes]) => {
+        return Promise.all([userRes.json(), gamesRes.json()]);
+      })
+      .then(([userData, gamesData]) => {
+        setUser(userData);
+        setGames(gamesData?.data || []);
+        setLoading(false);
+      })
+      .catch(() => {
+        setUser(null);
+        setGames([]);
+        setLoading(false);
+      });
+  }, []);
+
+  if (loading) {
+    return <div className="inner">로딩중...</div>;
+  }
 
   if (!user) {
     return (
@@ -21,7 +50,7 @@ export default function RecommendedGameSection() {
           <span className="text-primary-400">{user.nickname}님</span>이 좋아하실
           만한 게임
         </h2>
-        <RecommendedGameListWrapper games={gameListData.games} />
+        <RecommendedGameListWrapper games={games} />
       </div>
     </section>
   );

--- a/src/components/main/TrendingReviewSection.tsx
+++ b/src/components/main/TrendingReviewSection.tsx
@@ -5,6 +5,7 @@ import { type ReviewItem } from '@/types/user/review';
 interface ApiReviewPreview {
   game_id: number;
   nickname: string;
+  profile_image: string;
   rating: number;
   content: string;
   images: string;
@@ -25,7 +26,9 @@ const transformApiReviewToReviewItem = (
   user: {
     user_id: 0,
     username: apiReview.nickname,
-    profile_image_url: null,
+    profile_image_url: apiReview.profile_image
+      ? `https://kr.object.ncloudstorage.com/boardq/${apiReview.profile_image}`
+      : null,
   },
   image_url: apiReview.images || undefined,
 });

--- a/src/components/main/TrendingReviewSection.tsx
+++ b/src/components/main/TrendingReviewSection.tsx
@@ -1,16 +1,56 @@
-import { reviewData } from '@/assets/mocks/gameListData';
+import { fetcher } from '@/lib/fetcher';
 import TrendingReviewWrapper from './TrendingReviewWrapper';
+import { type ReviewItem } from '@/types/user/review';
 
-export default function TrendingReviewSection() {
-  const reviews = reviewData.reviews;
-  return (
-    <section className="inner">
-      <h2 className="mb-8 text-2xl font-bold md:text-3xl">지금 뜨는 리뷰</h2>
-      {reviewData.reviews.length === 0 ? (
-        <p className="text-gray-500">아직 작성된 리뷰가 없습니다.</p>
-      ) : (
-        <TrendingReviewWrapper reviews={reviews} />
-      )}
-    </section>
-  );
+interface ApiReviewPreview {
+  game_id: number;
+  nickname: string;
+  rating: number;
+  content: string;
+  images: string;
+  game_title: string;
+  created_at: string;
+}
+
+const transformApiReviewToReviewItem = (
+  apiReview: ApiReviewPreview,
+  index: number
+): ReviewItem => ({
+  review_id: index + 1,
+  game_id: apiReview.game_id,
+  title: apiReview.game_title,
+  content: apiReview.content,
+  rating: apiReview.rating,
+  created_at: apiReview.created_at,
+  user: {
+    user_id: 0,
+    username: apiReview.nickname,
+    profile_image_url: null,
+  },
+  image_url: apiReview.images || undefined,
+});
+
+export default async function TrendingReviewSection() {
+  try {
+    const apiReviews = await fetcher<ApiReviewPreview[]>('/reviews/preview/');
+    const reviews = apiReviews.map(transformApiReviewToReviewItem);
+
+    return (
+      <section className="inner">
+        <h2 className="mb-8 text-2xl font-bold md:text-3xl">지금 뜨는 리뷰</h2>
+        {reviews.length === 0 ? (
+          <p className="text-gray-500">아직 작성된 리뷰가 없습니다.</p>
+        ) : (
+          <TrendingReviewWrapper reviews={reviews} />
+        )}
+      </section>
+    );
+  } catch {
+    return (
+      <section className="inner">
+        <h2 className="mb-8 text-2xl font-bold md:text-3xl">지금 뜨는 리뷰</h2>
+        <p className="text-gray-500">리뷰를 불러오는데 실패했습니다.</p>
+      </section>
+    );
+  }
 }


### PR DESCRIPTION
- Closes #119   

## ✨ 작업 개요

- 메인 페이지의 모든 섹션을 실제 API와 연동하고 Mock 데이터를 제거했습니다.

## ✅ 작업 상세 내용

### API Routes 추가
- `src/app/api/user/route.ts` - 사용자 정보 조회 API
- `src/app/api/recommended-games/route.ts` - 추천 게임 API

### 컴포넌트 API 연동
- **RecommendedGameSection**: 사용자 기반 추천 게임 API 연동
- **NewAndHotGameSection**: 게임 랭킹 API 연동 (인기순/평점순)
- **MainBannerCarousel**: 게임 목록 API 연동으로 배너 데이터 표시
- **TrendingReviewSection**: 리뷰 미리보기 API 연동
- **GameThemeCuration**: API 연동
- **PreferenceSurveyCTA**: 사용자 인증 상태 기반 조건부 렌더링

### 기술적 개선
- Mock 데이터 의존성 제거
- 타입 안전성 강화 (TypeScript 인터페이스 정의)
- 서버/클라이언트 컴포넌트 적절한 분리
- CORS 문제 해결을 위한 API Route 패턴 적용

## 🔧 API 엔드포인트
- `/api/v1/recommendations` - 사용자 맞춤 추천 게임
- `/api/v1/games/ranking/` - 게임 랭킹 (좋아요순/평점순)
- `/api/v1/games/` - 게임 목록 (배너용)
- `/api/v1/reviews/preview/` - 인기 리뷰 미리보기
- `/api/v1/profile/` - 사용자 프로필 정보
