### PR TITLE
feat: 보드픽 설문 제출 화면 API 연동 (#118)

### DIFF
--- a/src/api/board-pick.ts
+++ b/src/api/board-pick.ts
@@ -22,22 +22,19 @@ export async function fetchTodayQuestion(step: number): Promise<Question> {
 export async function submitTodayAnswers(
   payload: TodaySubmitPayload
 ): Promise<TodaySubmitResponse> {
-  console.log('[Submit] payload', payload);
   const res = await fetch('/api/today/submit', {
     method: 'POST',
-    credentials: 'include',
     cache: 'no-store',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
+    next: { revalidate: 0 },
   });
 
   const text = await res.text().catch(() => '');
   if (!res.ok) {
-    console.error('[Submit] fail', res.status, text);
     throw new Error(`POST /api/today/submit ${res.status} ${text}`);
   }
 
   const json = JSON.parse(text) as TodaySubmitResponse;
-  console.log('[Submit] response', json);
   return json;
 }

--- a/src/app/api/likes/remove/route.ts
+++ b/src/app/api/likes/remove/route.ts
@@ -3,7 +3,6 @@ import { NextRequest, NextResponse } from 'next/server';
 
 export async function POST(req: NextRequest) {
   const token = await getAccessToken();
-  console.log('token : ', token);
   const { game_id } = await req.json();
 
   const res = await fetch(`https://boardq.o-r.kr/api/v1/likes/remove/`, {

--- a/src/app/api/today/submit/route.ts
+++ b/src/app/api/today/submit/route.ts
@@ -28,7 +28,6 @@ export async function POST(req: NextRequest) {
     const data = await res.json();
     return NextResponse.json(data, { status: res.status });
   } catch (err) {
-    console.error('Submit error:', err);
     return NextResponse.json({ message: 'Submit failed' }, { status: 500 });
   }
 }

--- a/src/app/my-page/profile/edit/_components/ProfileEditForm.tsx
+++ b/src/app/my-page/profile/edit/_components/ProfileEditForm.tsx
@@ -79,8 +79,7 @@ export default function ProfileEditForm({ userProfile }: ProfileEditFormProps) {
           router.refresh();
           router.push('/my-page/profile');
         },
-        onError: (err) => {
-          console.error('프로필 수정 실패:', err);
+        onError: () => {
           alert('수정에 실패했습니다. 다시 시도해주세요.');
         },
       }

--- a/src/app/today/_components/SurveySection.tsx
+++ b/src/app/today/_components/SurveySection.tsx
@@ -4,8 +4,14 @@ import { useTodayQuestions } from '@/hooks/react-query/useTodayQuestions';
 import { useBoardPickSurvey } from '@/hooks/useBoardPickSurvey';
 import { isAnswered } from '@/utils/boardPick';
 
-export default function SurveySection({ onSubmit }: { onSubmit: () => void }) {
-  const survey = useBoardPickSurvey();
+type SurveyModel = ReturnType<typeof useBoardPickSurvey>;
+export default function SurveySection({
+  onSubmit,
+  survey,
+}: {
+  onSubmit: () => void;
+  survey: SurveyModel;
+}) {
   const step = survey.step;
   const total = survey.total;
 

--- a/src/app/today/page.tsx
+++ b/src/app/today/page.tsx
@@ -35,7 +35,6 @@ export default function BoardPickPage() {
     if (submitting) return;
     try {
       setSubmitting(true);
-
       const payload = buildTodaySubmitPayload(
         survey.answers,
         survey.questionsByKey
@@ -45,7 +44,6 @@ export default function BoardPickPage() {
       sessionStorage.setItem(STORAGE_KEY, JSON.stringify(result));
       router.push(RESULT_PATH);
     } catch (e) {
-      console.error(e);
       alert('제출에 실패했어요. 잠시 후 다시 시도해주세요.');
     } finally {
       setSubmitting(false);
@@ -62,7 +60,7 @@ export default function BoardPickPage() {
   if (survey.phase === 'survey') {
     return (
       <GradientLayout>
-        <SurveySection onSubmit={submitAndGo} />
+        <SurveySection onSubmit={submitAndGo} survey={survey} />
       </GradientLayout>
     );
   }

--- a/src/app/today/result/page.tsx
+++ b/src/app/today/result/page.tsx
@@ -1,5 +1,8 @@
 'use client';
+import Spinner from '@/components/common/Spinner';
+import BoardPickResult from '@/components/preference/result/BoardPickResult';
 import { TodaySubmitResponse } from '@/types/board-pick/boardPick';
+import { GameListItem } from '@/types/game/game';
 import { useRouter } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
@@ -8,7 +11,6 @@ const STORAGE_KEY = 'today:result';
 export default function ResultPage() {
   const router = useRouter();
   const [data, setData] = useState<TodaySubmitResponse | null>(null);
-  // const res = await fetcher<GameListResponse>(`/games/?limit=6`);
 
   useEffect(() => {
     const raw = sessionStorage.getItem(STORAGE_KEY);
@@ -24,12 +26,43 @@ export default function ResultPage() {
     }
   }, [router]);
 
-  if (!data) return <div>불러오는 중...</div>;
+  if (!data)
+    return (
+      <div className="inner flex min-h-[60vh] flex-col items-center justify-center gap-4 text-center">
+        <Spinner size="lg" />
+        <p className="mb-10 text-gray-500">결과를 불러오는 중</p>
+      </div>
+    );
 
   const [first, second, third, ...rest] = data.games;
-  const result = [first, second, third];
-  const similar = rest;
+  const result = [first, second, third].map((game, i) => ({
+    game_id: game.game_id,
+    title: game.title,
+    difficulty: game.difficulty,
+    thumbnail_url: game.thumbnail_url,
+    average_rating: game.average_rating,
+    like_count: game.like_count,
+    genre: game.genre,
+    category: game.category,
+    quote: game.top_review?.content ?? '리뷰가 아직 없습니다.',
+    reviewer: game.top_review?.nickname ?? '익명',
+    description: game.description ?? '게임 설명이 준비중입니다.',
+  }));
 
-  // return <BoardPickResult result={result} similar={similar} />;
-  return <div>타입 에러 수정중...</div>;
+  const similar: GameListItem[] = rest.map((game, i) => ({
+    game_id: game.game_id,
+    title: game.title,
+    difficulty: game.difficulty.toString(),
+    thumbnail_url: game.thumbnail_url,
+    average_rating: game.average_rating,
+    like_count: game.like_count,
+    reviews_count: game.reviews_count,
+    genre: game.genre,
+    category: game.category,
+    age: 0,
+    description: '',
+    is_liked: false,
+  }));
+
+  return <BoardPickResult result={result} similar={similar} />;
 }

--- a/src/types/board-pick/boardPick.ts
+++ b/src/types/board-pick/boardPick.ts
@@ -3,6 +3,7 @@ export type QuestionType = 'single-select' | 'multi-select';
 export interface Option {
   id: number;
   label: string;
+  value?: string;
   min?: number;
   max?: number;
 }
@@ -31,13 +32,23 @@ export interface TodaySubmitResponse {
   games: TodayGame[];
 }
 
+export interface TopReview {
+  content?: string;
+  nickname?: string;
+}
+
 export interface TodayGame {
+  game_id: number;
   title: string;
   thumbnail_url: string;
   category: string;
   players: string;
   difficulty: string;
   genre: string;
-  description: string;
-  top_review?: Record<string, string>;
+  average_rating: number;
+  reviews_count: number;
+  like_count: number;
+  is_liked: boolean;
+  description: string | null;
+  top_review: TopReview | null;
 }

--- a/src/utils/boardPick.ts
+++ b/src/utils/boardPick.ts
@@ -36,9 +36,12 @@ const asIds = (v: AnswerValue): number[] | null =>
 const asId = (v: AnswerValue): number | null =>
   typeof v === 'number' ? v : null;
 
-function labelsFor(q: Question | undefined, ids: number[] | null): string[] {
+function valuesFor(q: Question | undefined, ids: number[] | null): string[] {
   if (!q || !ids || ids.length === 0) return [];
-  return q.options.filter((o) => ids.includes(o.id)).map((o) => o.label);
+  return q.options
+    .filter((o) => ids.includes(o.id))
+    .map((o) => o.value ?? o.label)
+    .filter((v): v is string => !!v);
 }
 
 function rangeFor(q: Question | undefined, id: number | null): Range {
@@ -60,11 +63,13 @@ export function buildTodaySubmitPayload(
   const qAge = questionsByKey['age_group'];
   const qDiff = questionsByKey['difficulty_range'];
 
-  return {
-    categories: labelsFor(qCat, asIds(answers['categories'])),
+  const payload: TodaySubmitPayload = {
+    categories: valuesFor(qCat, asIds(answers['categories'])),
     players_range: rangeFor(qP, asId(answers['players_range'])),
     playtime_range: rangeFor(qT, asId(answers['playtime_range'])),
     age_group: rangeFor(qAge, asId(answers['age_group'])),
     difficulty_range: rangeFor(qDiff, asId(answers['difficulty_range'])),
   };
+
+  return payload;
 }


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #118 

## ✨ 작업 개요

- 오늘의 보드게임 추천 설문 결과 API 연동
- 제출 payload 오류/결과 고정 이슈 해결

## ✅ 작업 상세 내용

- SurveySection.tsx : 부모에서 만든 useBoardPickSurvey() 인스턴스를 prop으로 주입하도록 변경
- today/page.tsx : survey={survey} 전달 
- today/result/page.tsx : API 응답(TodaySubmitResponse.games)을 결과/유사 리스트로 매핑 보강(옵셔널 필드 description, top_review 기본값 처리 포함)
- types/board-pick/boardPick.ts 
  - Option에 value?: string 추가
  - TodayGame 필드 정합성 맞춤
- utils/boardPick.ts
  - labelsFor → **valuesFor**로 변경: option.value ?? option.label을 사용해 카테고리 값 배열 생성
  - buildTodaySubmitPayload에서 categories에 값(value) 사용하도록 변경 

## 스크린샷

<img width="2002" height="6290" alt="localhost_3000_today_result (1)" src="https://github.com/user-attachments/assets/c207894f-9b0c-4d8c-8843-d319f492e336" />

