### PR TITLE
refactor: 메인페이지 캐러셀 스켈레톤 ui적용 및 푸터 옵션적용

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import Header from '@/components/layout/Header/Header';
 import type { Metadata } from 'next';
 import './globals.css';
 import Providers from './providers';
+import ConditionalFooter from '@/components/layout/ConditionalFooter';
 
 export const metadata: Metadata = {
   title: '보드큐',
@@ -28,7 +29,7 @@ export default function RootLayout({
         <Providers>
           <Header />
           {children}
-          <Footer />
+          <ConditionalFooter />
           <div id="modal" />
         </Providers>
       </body>

--- a/src/components/layout/ConditionalFooter.tsx
+++ b/src/components/layout/ConditionalFooter.tsx
@@ -1,0 +1,18 @@
+// components/layout/ConditionalFooter.tsx
+'use client';
+import { usePathname } from 'next/navigation';
+import Footer from './Footer';
+
+const HIDE_FOOTER_PAGES = [
+  '/auth/login',
+  '/auth/signup',
+  '/preference',
+  '/today',
+];
+
+export default function ConditionalFooter() {
+  const pathname = usePathname();
+  const hideFooter = HIDE_FOOTER_PAGES.includes(pathname);
+
+  return !hideFooter ? <Footer /> : null;
+}

--- a/src/components/main/MainBannerCarousel.tsx
+++ b/src/components/main/MainBannerCarousel.tsx
@@ -13,6 +13,7 @@ import 'swiper/css/navigation';
 import 'swiper/css/pagination';
 import { Autoplay, Navigation } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
+import MainBannerSkeleton from './MainBannerSkeleton';
 
 interface BannerGame {
   game_id: number;
@@ -40,7 +41,7 @@ export default function MainBannerCarousel() {
   }, []);
 
   if (loading) {
-    return <div className="relative mt-2 mb-16 h-96">로딩중...</div>;
+    return <MainBannerSkeleton />;
   }
 
   return (

--- a/src/components/main/MainBannerCarouselWrapper.tsx
+++ b/src/components/main/MainBannerCarouselWrapper.tsx
@@ -5,6 +5,7 @@ import MainBannerSkeleton from './MainBannerSkeleton';
 
 const MainBannerCarousel = dynamic(() => import('./MainBannerCarousel'), {
   ssr: false,
+  loading: () => <MainBannerSkeleton />,
 });
 
 export default function MainBannerCarouselWrapper() {


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #124  

## ✨ 작업 개요

- 메인페이지 캐러셀 화면 스켈레톤 Ui 적용
- 레이아웃에 푸터 전역적용이라 추가설정 적용


## ✅ 작업 상세 내용

- ConditionalFooter.tsx : path 설정으로 푸터를 제외하고 싶은 url경로 적용




