### PR TITLE
fix: 답변 미선택 시에도 다음 버튼 활성화되는 문제 (#127)

### DIFF
--- a/src/utils/boardPick.ts
+++ b/src/utils/boardPick.ts
@@ -24,9 +24,12 @@ export function makeInitialAnswers(questions: Question[]): AnswerMap {
  * - multi-select : 길이가 1 이상이면 true
  */
 export function isAnswered(q: Question, v: unknown): boolean {
-  return q.type === 'single-select'
-    ? v !== null
-    : Array.isArray(v) && v.length > 0;
+  if (q.type === 'single-select') {
+    return typeof v === 'number';
+  }
+  // 멀티: 최소 1개 이상 선택
+  if (Array.isArray(v)) return v.length > 0;
+  return false;
 }
 
 const ZERO: Range = { min: 0, max: 0 };


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #103

## ✨ 작업 개요

- isAnswered 로직 수정으로 미선택 시 다음 버튼 비활성화되는 버그 해결

## ✅ 작업 상세 내용

* single-select: 숫자(id) 선택 시에만 정답으로 처리
* multi-select: 배열이며 length > 0일 때만 정답으로 처리
* 그 외(undefined/null)는 false 반환 → 답변 미선택 시 다음 버튼 비활성화
