### PR TITLE
feat: 게임 상세/리스트 SSR-CSR 통합 및 좋아요·유튜브 연동 기능 구현 (#114)

### DIFF
--- a/src/app/api/games/[gameId]/route.ts
+++ b/src/app/api/games/[gameId]/route.ts
@@ -4,7 +4,7 @@ import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(
   request: NextRequest,
-  { params }: { params: { gameId: string } }
+  { params }: { params: { gameId: number } }
 ) {
   const { gameId } = await params;
   const token = await getAccessToken();

--- a/src/app/api/games/[gameId]/route.ts
+++ b/src/app/api/games/[gameId]/route.ts
@@ -1,14 +1,20 @@
 import { API_BASE_URL } from '@/constants/api/url';
+import { getAccessToken } from '@/lib/getAccessToken';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(
   request: NextRequest,
   { params }: { params: { gameId: string } }
 ) {
-  const { gameId } = params;
+  const { gameId } = await params;
+  const token = await getAccessToken();
 
   try {
-    const res = await fetch(`${API_BASE_URL}/games/${gameId}`);
+    const res = await fetch(`${API_BASE_URL}/games/${gameId}`, {
+      headers: {
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      },
+    });
 
     if (!res.ok) {
       const errorInfo = await res.json();

--- a/src/app/api/games/[gameId]/route.ts
+++ b/src/app/api/games/[gameId]/route.ts
@@ -1,0 +1,27 @@
+import { API_BASE_URL } from '@/constants/api/url';
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: { gameId: string } }
+) {
+  const { gameId } = params;
+
+  try {
+    const res = await fetch(`${API_BASE_URL}/games/${gameId}`);
+
+    if (!res.ok) {
+      const errorInfo = await res.json();
+      return NextResponse.json(errorInfo, { status: res.status });
+    }
+
+    const data = await res.json();
+    return NextResponse.json(data);
+  } catch (error) {
+    console.error('Error in API handler:', error);
+    return NextResponse.json(
+      { message: 'Internal Server Error' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/api/games/route.ts
+++ b/src/app/api/games/route.ts
@@ -1,8 +1,9 @@
+import { API_BASE_URL } from '@/constants/api/url';
+import { getAccessToken } from '@/lib/getAccessToken';
 import { NextRequest, NextResponse } from 'next/server';
 
-const API_BASE_URL = 'https://boardq.o-r.kr/api/v1';
-
 export async function GET(request: NextRequest) {
+  const token = await getAccessToken();
   try {
     const { searchParams } = new URL(request.url);
 
@@ -50,7 +51,11 @@ export async function GET(request: NextRequest) {
     setIf('age', age);
 
     // 서버 간 통신이므로 CORS 에러 발생하지 않음
-    const res = await fetch(externalApiUrl.toString());
+    const res = await fetch(externalApiUrl.toString(), {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    });
 
     if (!res.ok) {
       const errorInfo = await res.json();

--- a/src/app/api/games/route.ts
+++ b/src/app/api/games/route.ts
@@ -53,7 +53,7 @@ export async function GET(request: NextRequest) {
     // 서버 간 통신이므로 CORS 에러 발생하지 않음
     const res = await fetch(externalApiUrl.toString(), {
       headers: {
-        Authorization: `Bearer ${token}`,
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
       },
     });
 

--- a/src/app/api/likes/route.ts
+++ b/src/app/api/likes/route.ts
@@ -1,9 +1,9 @@
+import { API_BASE_URL } from '@/constants/api/url';
 import { getAccessToken } from '@/lib/getAccessToken';
 import { NextRequest, NextResponse } from 'next/server';
 
 export async function GET(req: NextRequest) {
   const token = await getAccessToken();
-
   if (!token) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
@@ -23,5 +23,32 @@ export async function GET(req: NextRequest) {
   );
 
   const data = await response.json();
+  return NextResponse.json(data);
+}
+
+export async function POST(req: NextRequest) {
+  const token = await getAccessToken();
+  if (!token) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { game_id } = await req.json();
+  console.log('test');
+
+  const res = await fetch(`${API_BASE_URL}/likes/`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({ game_id }),
+    credentials: 'include', // 세션/쿠키 인증 필요할 경우
+  });
+
+  if (!res.ok) {
+    throw new Error('Failed to toggle like');
+  }
+
+  const data = await res.json(); // 서버 응답 (좋아요 여부 등)
   return NextResponse.json(data);
 }

--- a/src/app/api/youtube/route.ts
+++ b/src/app/api/youtube/route.ts
@@ -1,0 +1,45 @@
+// export async function fetchYoutubeVideos(
+//   gameTitle: string
+// ): Promise<string | null> {
+//   const apiKey = process.env.YOUTUBE_API_KEY;
+
+//   const params = {
+//     part: 'snippet',
+//     maxResults: '1',
+//     q: `${gameTitle} 보드게임 하는 법`,
+//     type: 'video',
+//     key: apiKey ?? '',
+//     regionCode: 'KR',
+//   };
+
+//   const url = new URL('https://www.googleapis.com/youtube/v3/search');
+//   url.search = new URLSearchParams(params).toString();
+
+//   const response = await fetch(url);
+//   const data = await response.json();
+//   return data.items[0]?.id?.videoId || null;
+// }
+
+// app/api/youtube/route.ts
+import { NextRequest, NextResponse } from 'next/server';
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url);
+  const title = searchParams.get('title');
+
+  const apiKey = process.env.YOUTUBE_API_KEY; // 서버 전용
+  const url = new URL('https://www.googleapis.com/youtube/v3/search');
+  url.search = new URLSearchParams({
+    part: 'snippet',
+    maxResults: '1',
+    q: `${title} 보드게임 하는 법`,
+    type: 'video',
+    key: apiKey ?? '',
+    regionCode: 'KR',
+  }).toString();
+
+  const res = await fetch(url, { cache: 'no-store' });
+  const data = await res.json();
+
+  return NextResponse.json(data);
+}

--- a/src/app/games/[id]/_components/GameDetailBottomSection.tsx
+++ b/src/app/games/[id]/_components/GameDetailBottomSection.tsx
@@ -1,7 +1,7 @@
 import GameDetailInfo from '@/app/games/[id]/_components/GameDetailInfo';
 import GameReviewSection from '@/app/games/[id]/_components/GameReviewSection';
-import YoutubeVideoSection from '@/app/games/[id]/_components/YoutubeVideoSection';
 // import SimilarGameList from '@/components/game/detail/SimilarGameList';
+import YoutubeVideoSection from '@/app/games/[id]/_components/YoutubeVideoSection';
 import Grid from '@/components/layout/Grid';
 import { GameDetail } from '@/types/game/game';
 import { ReviewListResponse } from '@/types/user/review';

--- a/src/app/games/[id]/_components/GameDetailPageHeader.tsx
+++ b/src/app/games/[id]/_components/GameDetailPageHeader.tsx
@@ -1,18 +1,22 @@
 'use client';
 import LikeButton from '@/components/game/LikeButton';
+import BreadcrumbsSkeleton from '@/components/layout/BreadcrumbsSkeleton';
 import dynamic from 'next/dynamic';
 
 const Breadcrumbs = dynamic(() => import('@/components/layout/Breadcrumbs'), {
   ssr: false,
+  loading: () => <BreadcrumbsSkeleton />,
 });
 
 interface GameDetailPageHeaderProps {
   title: string;
+  is_liked: boolean;
   gameId: number;
 }
 
 export default function GameDetailPageHeader({
   title,
+  is_liked,
   gameId,
 }: GameDetailPageHeaderProps) {
   return (
@@ -21,7 +25,7 @@ export default function GameDetailPageHeader({
       <h1 className="mt-4 mb-6 flex items-center gap-2 text-2xl font-bold md:mt-6 md:mb-12 md:text-4xl">
         {title}
         <LikeButton
-          liked={false}
+          liked={is_liked}
           gameId={gameId}
           className="relative"
           lineColor="text-gray-300"

--- a/src/app/games/[id]/_components/GameDetailUI.tsx
+++ b/src/app/games/[id]/_components/GameDetailUI.tsx
@@ -1,26 +1,37 @@
-import { GameDetail } from '@/types/game/game';
-import { ReviewListResponse } from '@/types/user/review';
+'use client';
+import { getGameDataClient } from '@/lib/api/gameDetail';
+import { getReviewDataClient } from '@/lib/api/reviews';
+import { useQuery } from '@tanstack/react-query';
 import { notFound } from 'next/navigation';
 import GameDetailBottomSection from './GameDetailBottomSection';
 import GameDetailPageHeader from './GameDetailPageHeader';
 import GameDetailTopSection from './GameDetailTopSection';
 
-interface GameDetailPageProps {
-  game: GameDetail;
-  reviewData: ReviewListResponse;
-}
+export default function GameDetailUI({ id }: { id: number }) {
+  const { data: game, isLoading: isGameLoading } = useQuery({
+    queryKey: ['game', id],
+    queryFn: () => getGameDataClient(id),
+  });
+  const { data: reviewData } = useQuery({
+    queryKey: ['reviews', id],
+    queryFn: () => getReviewDataClient(id),
+  });
 
-export default function GameDetailUI({
-  game,
-  reviewData,
-}: GameDetailPageProps) {
+  if (isGameLoading) return <div>Loading...</div>;
+
+  if (!isGameLoading && !game) return notFound();
+
   if (!game) {
     notFound();
   }
 
   return (
     <div className="inner pt-6 pb-40">
-      <GameDetailPageHeader title={game.title} gameId={game.game_id} />
+      <GameDetailPageHeader
+        title={game.title}
+        is_liked={game.is_liked}
+        gameId={game.game_id}
+      />
       {/* 게임 상세 상단 */}
       <GameDetailTopSection game={game} />
 

--- a/src/app/games/[id]/_components/YoutubeVideoSection.tsx
+++ b/src/app/games/[id]/_components/YoutubeVideoSection.tsx
@@ -1,44 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+
 interface YoutubeVideoSectionProps {
   gameTitle: string;
 }
 
-async function fetchYoutubeVideos(gameTitle: string): Promise<string | null> {
-  const apiKey = process.env.YOUTUBE_API_KEY;
-
-  const params = {
-    part: 'snippet',
-    maxResults: '1',
-    q: `${gameTitle} 보드게임 하는 법`,
-    type: 'video',
-    key: apiKey ?? '',
-    regionCode: 'KR',
-  };
-
-  const url = new URL('https://www.googleapis.com/youtube/v3/search');
-  url.search = new URLSearchParams(params).toString();
-
-  const response = await fetch(url);
-  const data = await response.json();
-  return data.items[0]?.id?.videoId || null;
-}
-
-export default async function YoutubeVideoSection({
+export default function YoutubeVideoSection({
   gameTitle,
 }: YoutubeVideoSectionProps) {
-  let youtubeVideo: string | null = null;
-
-  try {
-    youtubeVideo = await fetchYoutubeVideos(gameTitle);
-  } catch (error) {
-    // eslint-disable-next-line no-console
-    console.error('YouTube API 호출 실패:', error);
-  }
+  const { data: videoId } = useQuery({
+    queryKey: ['youtube', gameTitle],
+    queryFn: async () => {
+      const res = await fetch(
+        `/api/youtube?title=${encodeURIComponent(gameTitle)}`
+      );
+      const data = await res.json();
+      return data.items[0]?.id?.videoId ?? null;
+    },
+  });
 
   return (
     <div className="relative aspect-video w-full overflow-hidden rounded-xl bg-gray-100">
       <iframe
         id="ytplayer"
-        src={`https://www.youtube.com/embed/${youtubeVideo}?autoplay=0&controls=1`}
+        src={`https://www.youtube.com/embed/${videoId}?autoplay=0&controls=1`}
         width="100%"
         height="100%"
         allowFullScreen

--- a/src/app/games/[id]/page.tsx
+++ b/src/app/games/[id]/page.tsx
@@ -1,51 +1,34 @@
-import { ApiError, fetcher } from '@/lib/fetcher';
-import { GameDetail } from '@/types/game/game';
-import { ReviewListResponse } from '@/types/user/review';
-import { notFound } from 'next/navigation';
+import { getGameData } from '@/lib/api/gameDetail';
+import { getReviewData } from '@/lib/api/reviews';
+import getQueryClient from '@/lib/getQueryClient';
+import { dehydrate, HydrationBoundary } from '@tanstack/react-query';
 import GameDetailUI from './_components/GameDetailUI';
-
-async function getGameData(id: string) {
-  try {
-    return await fetcher<GameDetail>(`/games/${id}`);
-  } catch (e) {
-    if (e instanceof ApiError && e.status === 404) {
-      notFound();
-    }
-    throw e;
-  }
-}
-
-async function getReviewData(id: string) {
-  try {
-    return await fetcher<ReviewListResponse>(
-      `/games/${id}/reviews?limit=4&page=1`
-    );
-  } catch (e) {
-    if (e instanceof ApiError && e.status === 400) {
-      const emptyResponse: ReviewListResponse = {
-        state: 'failure',
-        title: '',
-        thumbnail_url: '',
-        total_reviews: 0,
-        page: 1,
-        limit: 10,
-        total_pages: 1,
-        reviews: [],
-      };
-      return emptyResponse;
-    }
-    throw e;
-  }
-}
 
 export default async function GameDetailPage({
   params,
 }: {
-  params: Promise<{ id: string }>;
+  params: Promise<{ id: number }>;
 }) {
   const { id } = await params;
-  const gameResponse = await getGameData(id);
-  const reviewResponse = await getReviewData(id);
+  // const gameResponse = await getGameData(id);
+  // const reviewResponse = await getReviewData(id);
 
-  return <GameDetailUI game={gameResponse} reviewData={reviewResponse} />;
+  const queryClient = getQueryClient();
+
+  await queryClient.prefetchQuery({
+    queryKey: ['game', id],
+    queryFn: () => getGameData(id),
+  });
+
+  await queryClient.prefetchQuery({
+    queryKey: ['reviews', id],
+    queryFn: () => getReviewData(id),
+  });
+
+  // return <GameDetailUI game={gameResponse} reviewData={reviewResponse} />;
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <GameDetailUI id={id} />
+    </HydrationBoundary>
+  );
 }

--- a/src/app/games/_components/GameListUI.tsx
+++ b/src/app/games/_components/GameListUI.tsx
@@ -2,8 +2,10 @@
 import GameListSection from '@/app/games/_components/GameListSection';
 import BreadcrumbsSkeleton from '@/components/layout/BreadcrumbsSkeleton';
 import Grid from '@/components/layout/Grid';
-import { GameListResponse } from '@/types/game/game';
+import { getGameListDataClient } from '@/lib/api/games';
+import { useQuery } from '@tanstack/react-query';
 import dynamic from 'next/dynamic';
+import { notFound } from 'next/navigation';
 import FilterSidebarSkeleton from './FilterSidebarSkeleton';
 
 const Breadcrumbs = dynamic(() => import('@/components/layout/Breadcrumbs'), {
@@ -19,10 +21,18 @@ const FilterSidebar = dynamic(
 );
 
 export default function GameListUI({
-  gameListData,
+  searchParams,
 }: {
-  gameListData: GameListResponse;
+  searchParams: { [key: string]: string | string[] | undefined };
 }) {
+  const { data: gameListData, isLoading } = useQuery({
+    queryKey: ['games', searchParams],
+    queryFn: () => getGameListDataClient(searchParams),
+  });
+  if (isLoading) return <div>Loading...</div>;
+
+  if (!isLoading && !gameListData) return notFound();
+
   return (
     <div className="inner pt-6 pb-40">
       <Breadcrumbs />

--- a/src/app/games/page.tsx
+++ b/src/app/games/page.tsx
@@ -1,37 +1,50 @@
 import GameListUI from '@/app/games/_components/GameListUI';
-import { fetcher } from '@/lib/fetcher';
-import { GameListResponse } from '@/types/game/game';
+import { getGameListData } from '@/lib/api/games';
+import getQueryClient from '@/lib/getQueryClient';
+import { HydrationBoundary, dehydrate } from '@tanstack/react-query';
+import { Metadata } from 'next';
 
-async function getGameListData({
+export async function generateMetadata({
   searchParams,
 }: {
-  searchParams: { [key: string]: string | string[] | undefined };
-}) {
+  searchParams: Promise<{ [key: string]: string | string[] | undefined }>;
+}): Promise<Metadata> {
   const resolvedParams = await searchParams;
+  const category = resolvedParams.category;
 
-  // searchParams를 URLSearchParams로 변환
-  const params = new URLSearchParams(
-    Object.entries(resolvedParams).flatMap(([key, value]) => {
-      if (typeof value === 'undefined') return [];
-      if (Array.isArray(value)) {
-        return value.map((v) => [key, v]);
-      }
-      return [[key, value]];
-    })
-  );
+  const title = category
+    ? `보드큐 - ${category} 보드게임 리스트`
+    : '보드큐 - 보드게임 리스트';
+  const description = category
+    ? `${category} 보드게임을 한눈에 확인하세요`
+    : '다양한 보드게임을 쉽게 검색하세요!';
 
-  // 기본 URL 설정
-  const endpoint = `/games/?${params.toString()}`;
-
-  const res = await fetcher<GameListResponse>(endpoint);
-  return res;
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+    },
+  };
 }
-
 export default async function Page({
   searchParams,
 }: {
   searchParams: { [key: string]: string | string[] | undefined };
 }) {
-  const gameListData = await getGameListData({ searchParams });
-  return <GameListUI gameListData={gameListData} />;
+  const queryClient = getQueryClient();
+
+  const resolvedParams = await searchParams;
+
+  await queryClient.prefetchQuery({
+    queryKey: ['games', resolvedParams],
+    queryFn: () => getGameListData(resolvedParams),
+  });
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <GameListUI searchParams={resolvedParams} />
+    </HydrationBoundary>
+  );
 }

--- a/src/app/games/page.tsx
+++ b/src/app/games/page.tsx
@@ -13,8 +13,8 @@ export async function generateMetadata({
   const category = resolvedParams.category;
 
   const title = category
-    ? `보드큐 - ${category} 보드게임 리스트`
-    : '보드큐 - 보드게임 리스트';
+    ? `보드큐 - ${category} 보드게임 찾기`
+    : '보드큐 - 보드게임 찾기';
   const description = category
     ? `${category} 보드게임을 한눈에 확인하세요`
     : '다양한 보드게임을 쉽게 검색하세요!';

--- a/src/components/game/LikeButton.tsx
+++ b/src/components/game/LikeButton.tsx
@@ -1,10 +1,8 @@
 'use client';
-import { useToast } from '@/hooks/useToast';
+import { useToggleLike } from '@/hooks/react-query/useToggleLike';
 import { cn } from '@/utils/cn';
 import { RiHeartFill, RiHeartLine } from '@remixicon/react';
-import { useRouter } from 'next/navigation';
 import { useState } from 'react';
-import { Toast } from '../common/Toast';
 
 interface LikeButtonProps {
   liked: boolean;
@@ -20,65 +18,26 @@ export default function LikeButton({
   lineColor = 'text-white',
 }: LikeButtonProps) {
   const [isLiked, setIsLiked] = useState(liked);
-  const router = useRouter();
-  const { toasts, success, error } = useToast();
-
-  const handleLikeClick = async (e: React.MouseEvent) => {
+  const { mutate } = useToggleLike(gameId);
+  const handleClick = (e: React.MouseEvent) => {
     e.stopPropagation();
     e.preventDefault();
-
-    try {
-      const res = await fetch(`/api/likes/`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ game_id: gameId }),
-      });
-
-      const data = await res.json();
-
-      if (!res.ok) {
-        if (res.status === 401) {
-          success('로그인이 필요합니다.');
-          router.push(`/auth/login`);
-        } else {
-          let message = '알 수 없는 오류가 발생했습니다.';
-          if (typeof data?.action === 'string') {
-            message = data.action;
-          }
-          success(message);
-        }
-        return;
-      }
-
-      // ✅ 서버 응답 기반으로 상태 세팅
-      if (data.action === 'added') {
-        setIsLiked(true);
-        success('좋아요 되었습니다.');
-      } else if (data.action === 'removed') {
-        setIsLiked(false);
-        success('좋아요가 취소되었습니다.');
-      }
-    } catch (error) {
-      console.error(error);
-      // 실패 시 상태 롤백 가능 (옵션)
-    }
+    setIsLiked((prev) => !prev); // ✅ Optimistic UI
+    mutate(undefined, {
+      onError: () => setIsLiked(liked), // 실패 시 롤백
+    });
   };
 
   return (
-    <>
-      <Toast toasts={toasts} />
-      <button
-        onClick={handleLikeClick}
-        className={cn('z-10 cursor-pointer p-2', className)}
-      >
-        {isLiked ? (
-          <RiHeartFill className="text-primary-400 h-6 w-6" />
-        ) : (
-          <RiHeartLine className={`h-6 w-6 ${lineColor}`} />
-        )}
-      </button>
-    </>
+    <button
+      onClick={handleClick}
+      className={cn('z-10 cursor-pointer p-2', className)}
+    >
+      {isLiked ? (
+        <RiHeartFill className="text-primary-400 h-6 w-6" />
+      ) : (
+        <RiHeartLine className={`h-6 w-6 ${lineColor}`} />
+      )}
+    </button>
   );
 }

--- a/src/components/game/LikeButton.tsx
+++ b/src/components/game/LikeButton.tsx
@@ -1,7 +1,10 @@
 'use client';
+import { useToast } from '@/hooks/useToast';
 import { cn } from '@/utils/cn';
 import { RiHeartFill, RiHeartLine } from '@remixicon/react';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
+import { Toast } from '../common/Toast';
 
 interface LikeButtonProps {
   liked: boolean;
@@ -12,27 +15,70 @@ interface LikeButtonProps {
 
 export default function LikeButton({
   liked = false,
-  gameId: _gameId,
+  gameId,
   className,
   lineColor = 'text-white',
 }: LikeButtonProps) {
   const [isLiked, setIsLiked] = useState(liked);
-  const handleLikeClick = (e: React.MouseEvent) => {
+  const router = useRouter();
+  const { toasts, success, error } = useToast();
+
+  const handleLikeClick = async (e: React.MouseEvent) => {
     e.stopPropagation();
     e.preventDefault();
-    setIsLiked((prev) => !prev);
+
+    try {
+      const res = await fetch(`/api/likes/`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ game_id: gameId }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        if (res.status === 401) {
+          success('로그인이 필요합니다.');
+          router.push(`/auth/login`);
+        } else {
+          let message = '알 수 없는 오류가 발생했습니다.';
+          if (typeof data?.action === 'string') {
+            message = data.action;
+          }
+          success(message);
+        }
+        return;
+      }
+
+      // ✅ 서버 응답 기반으로 상태 세팅
+      if (data.action === 'added') {
+        setIsLiked(true);
+        success('좋아요 되었습니다.');
+      } else if (data.action === 'removed') {
+        setIsLiked(false);
+        success('좋아요가 취소되었습니다.');
+      }
+    } catch (error) {
+      console.error(error);
+      // 실패 시 상태 롤백 가능 (옵션)
+    }
   };
 
   return (
-    <button
-      onClick={handleLikeClick}
-      className={cn('z-10 cursor-pointer p-2', className)}
-    >
-      {isLiked ? (
-        <RiHeartFill className="text-primary-400 h-6 w-6" />
-      ) : (
-        <RiHeartLine className={`h-6 w-6 ${lineColor}`} />
-      )}
-    </button>
+    <>
+      <Toast toasts={toasts} />
+      <button
+        onClick={handleLikeClick}
+        className={cn('z-10 cursor-pointer p-2', className)}
+      >
+        {isLiked ? (
+          <RiHeartFill className="text-primary-400 h-6 w-6" />
+        ) : (
+          <RiHeartLine className={`h-6 w-6 ${lineColor}`} />
+        )}
+      </button>
+    </>
   );
 }

--- a/src/hooks/react-query/useToggleLike.ts
+++ b/src/hooks/react-query/useToggleLike.ts
@@ -1,0 +1,35 @@
+'use client';
+
+import { useToast } from '@/hooks/useToast';
+import { toggleLikeApi } from '@/lib/api/like';
+import { ApiError } from '@/types/api';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+
+export function useToggleLike(gameId: number) {
+  const router = useRouter();
+  const { success, error } = useToast();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => toggleLikeApi(gameId),
+    onSuccess: (data) => {
+      if (data.action === 'added') {
+        success('좋아요 되었습니다.');
+      } else {
+        success('좋아요가 취소되었습니다.');
+      }
+      // ✅ 게임 리스트/상세 invalidate → UI 자동 갱신
+      queryClient.invalidateQueries({ queryKey: ['games'] });
+      queryClient.invalidateQueries({ queryKey: ['game', gameId] });
+    },
+    onError: (err: ApiError) => {
+      if (err.status === 401) {
+        success('로그인이 필요합니다.');
+        router.push('/auth/login');
+      } else {
+        error(err.message ?? '알 수 없는 오류가 발생했습니다.');
+      }
+    },
+  });
+}

--- a/src/lib/api/gameDetail.ts
+++ b/src/lib/api/gameDetail.ts
@@ -1,0 +1,26 @@
+import { ApiError, fetcher } from '@/lib/fetcher';
+import { GameDetail } from '@/types/game/game';
+import { notFound } from 'next/navigation';
+import { getAccessToken } from '../getAccessToken';
+
+export async function getGameData(id: number) {
+  const token = await getAccessToken();
+
+  try {
+    return await fetcher<GameDetail>(`/games/${id}`, undefined, token);
+  } catch (e) {
+    if (e instanceof ApiError && e.status === 404) {
+      notFound();
+    }
+    throw e;
+  }
+}
+
+export async function getGameDataClient(id: number) {
+  const res = await fetch(`/api/games/${id}`, {
+    method: 'GET',
+  });
+  console.log('여기들어옴');
+  if (!res.ok) throw new Error(`Error ${res.status}`);
+  return res.json();
+}

--- a/src/lib/api/games.ts
+++ b/src/lib/api/games.ts
@@ -1,0 +1,42 @@
+import { fetcher } from '@/lib/fetcher';
+import { GameListResponse } from '@/types/game/game';
+import { getAccessToken } from '../getAccessToken';
+
+export async function getGameListData(searchParams: {
+  [key: string]: string | string[] | undefined;
+}) {
+  const token = await getAccessToken();
+
+  // searchParams를 URLSearchParams로 변환
+  const params = new URLSearchParams(
+    Object.entries(searchParams).flatMap(([key, value]) => {
+      if (typeof value === 'undefined') return [];
+      if (Array.isArray(value)) {
+        return value.map((v) => [key, v]);
+      }
+      return [[key, value]];
+    }) || { page: 1 }
+  );
+
+  const endpoint = `/games/?${params.toString()}`;
+  return fetcher<GameListResponse>(endpoint, undefined, token);
+}
+
+export async function getGameListDataClient(searchParams: {
+  [key: string]: string | string[] | undefined;
+}) {
+  const params = new URLSearchParams(
+    Object.entries(searchParams).flatMap(([key, value]) => {
+      if (typeof value === 'undefined') return [];
+      if (Array.isArray(value)) {
+        return value.map((v) => [key, v]);
+      }
+      return [[key, value]];
+    }) || { page: 1 }
+  );
+  const res = await fetch(`/api/games?${params.toString()}`, {
+    method: 'GET',
+  });
+  if (!res.ok) throw new Error(`Error ${res.status}`);
+  return res.json();
+}

--- a/src/lib/api/like.ts
+++ b/src/lib/api/like.ts
@@ -1,0 +1,15 @@
+// lib/api/likes.ts
+export async function toggleLikeApi(gameId: number) {
+  const res = await fetch(`/api/likes/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ game_id: gameId }),
+  });
+
+  const data = await res.json();
+  if (!res.ok) {
+    throw { status: res.status, message: data?.action ?? '알 수 없는 오류' };
+  }
+
+  return data; // { action: 'added' | 'removed' }
+}

--- a/src/lib/api/reviews.ts
+++ b/src/lib/api/reviews.ts
@@ -1,0 +1,33 @@
+import { ApiError, fetcher } from '@/lib/fetcher';
+import { ReviewListResponse } from '@/types/user/review';
+
+export async function getReviewData(id: number) {
+  try {
+    return await fetcher<ReviewListResponse>(
+      `/games/${id}/reviews?limit=4&page=1`
+    );
+  } catch (e) {
+    if (e instanceof ApiError && e.status === 400) {
+      const emptyResponse: ReviewListResponse = {
+        state: 'failure',
+        title: '',
+        thumbnail_url: '',
+        total_reviews: 0,
+        page: 1,
+        limit: 10,
+        total_pages: 1,
+        reviews: [],
+      };
+      return emptyResponse;
+    }
+    throw e;
+  }
+}
+
+export async function getReviewDataClient(id: number) {
+  const res = await fetch(`/api/games/${id}/reviews`, {
+    method: 'GET',
+  });
+  if (!res.ok) throw new Error(`Error ${res.status}`);
+  return res.json();
+}

--- a/src/lib/fetcher.ts
+++ b/src/lib/fetcher.ts
@@ -14,11 +14,12 @@ export class ApiError extends Error {
 export async function fetcher<T>(
   endpoint: string,
   options?: RequestInit,
-  accessToken?: string // SSR일 경우 직접 전달
+  accessToken?: string | null // SSR일 경우 직접 전달
 ): Promise<T> {
   const isFormData = options?.body instanceof FormData;
 
   const res = await fetch(`${API_BASE_URL}${endpoint}`, {
+    credentials: 'include',
     ...options,
     headers: {
       // FormData일 때는 Content-Type을 설정하지 않음 (브라우저가 자동으로 multipart/form-data 설정)

--- a/src/lib/getQueryClient.ts
+++ b/src/lib/getQueryClient.ts
@@ -1,0 +1,10 @@
+import { QueryClient } from '@tanstack/react-query';
+
+let client: QueryClient | null = null;
+
+export default function getQueryClient() {
+  if (!client) {
+    client = new QueryClient();
+  }
+  return client;
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1,0 +1,4 @@
+export type ApiError = {
+  status: number;
+  message: string;
+};


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #114 
- #131
- #45 

## ✨ 작업 개요

* 게임 상세 및 리스트 페이지 SSR/CSR 통합 구조 도입
* TanStack Query 기반 API 연동 구조 개선
* 좋아요 기능 및 유튜브 영상 연동 기능 추가
* 인증 토큰 처리 및 fetch 구조 개선

## ✅ 작업 상세 내용

* **게임 리스트/상세 SSR → CSR 전환**

  * `getQueryClient`, `HydrationBoundary`, `dehydrate` 구조 적용
  * 서버에서 prefetch, 클라이언트에서 `useQuery` 기반 데이터 요청

* **API 유틸 및 라우트 정비**

  * `/api/games`, `/api/games/[id]` 프록시 라우트 구현
  * 서버에서 `getAccessToken()` 호출 → 조건부 Authorization 헤더 포함
  * 클라이언트 전용 `getGameListDataClient`, `getGameDataClient` 유틸 함수 추가

* **좋아요 기능 구현 및 리팩토링**

  * `POST /api/likes` API 라우트 구현 (토큰 인증 포함)
  * `LikeButton`에서 서버 요청 분리 → `useToggleLike` 커스텀 훅 생성
  * Optimistic UI 및 실패 시 롤백 처리 적용
  * 쿼리 invalidate로 게임 리스트 및 상세 좋아요 상태 동기화

* **리뷰 API 유틸 구성**

  * `/api/games/[id]/reviews` 라우트 및 클라이언트 요청 함수 분리
  * 에러 발생 시 빈 리스트 반환으로 UI 안정성 확보

* **유튜브 영상 연동 기능 추가**

  * `/api/youtube` API 라우트 생성 (서버에서 API 키 사용)
  * `YoutubeVideoSection` 컴포넌트 CSR 방식 전환 및 React Query 사용
  * 검색어: `<게임 제목> 보드게임 하는 법` 기준 유튜브 영상 임베드

* **SEO 및 메타데이터 개선**

  * 페이지 제목/설명: `보드게임 리스트` → `보드게임 찾기`로 개선
  * 카테고리 기반 동적 메타데이터 생성


## 스크린샷
![Aug-21-2025 03-29-02](https://github.com/user-attachments/assets/18539f97-c555-4de4-b34b-c35625000aec)

