### PR TITLE
feat: 게임 상세페이지 비슷한 게임목록 CSR 및 React Query 적용, 데이터 정리 (#115)

### DIFF
--- a/src/app/games/[id]/_components/GameDetailBottomSection.tsx
+++ b/src/app/games/[id]/_components/GameDetailBottomSection.tsx
@@ -1,7 +1,7 @@
 import GameDetailInfo from '@/app/games/[id]/_components/GameDetailInfo';
 import GameReviewSection from '@/app/games/[id]/_components/GameReviewSection';
-// import SimilarGameList from '@/components/game/detail/SimilarGameList';
 import YoutubeVideoSection from '@/app/games/[id]/_components/YoutubeVideoSection';
+import SimilarGameList from '@/components/game/detail/SimilarGameList';
 import Grid from '@/components/layout/Grid';
 import { GameDetail } from '@/types/game/game';
 import { ReviewListResponse } from '@/types/user/review';
@@ -45,7 +45,7 @@ export default function GameDetailBottomSection({
         <div className="game-detail-section">
           <h2 className="game-detail-title">비슷한 게임</h2>
           <div className="space-y-6">
-            {/* <SimilarGameList genre={game.genre} /> */}
+            <SimilarGameList genre={game.genre} />
           </div>
         </div>
       </Grid.Item>

--- a/src/app/games/[id]/_components/GameDetailInfo.tsx
+++ b/src/app/games/[id]/_components/GameDetailInfo.tsx
@@ -1,21 +1,12 @@
 'use client';
 import { GameDetail } from '@/types/game/game';
-import { formatDate } from '@/utils/formatDate';
 import { formatDifficulty } from '@/utils/formatDifficulty';
 
 interface GameDetailInfoProps {
   game: GameDetail;
 }
 export default function GameDetailInfo({ game }: GameDetailInfoProps) {
-  const {
-    min_players,
-    max_players,
-    difficulty,
-    playtime_minutes,
-    genre,
-    age,
-    created_at,
-  } = game;
+  const { min_players, max_players, difficulty, play_time, genre, age } = game;
 
   const gameDetailInfo = [
     {
@@ -28,7 +19,7 @@ export default function GameDetailInfo({ game }: GameDetailInfoProps) {
     },
     {
       label: '플레이 시간',
-      value: playtime_minutes ? `${playtime_minutes}분` : '알수없음',
+      value: play_time ? `${play_time}` : '알수없음',
     },
     {
       label: '장르',
@@ -37,10 +28,6 @@ export default function GameDetailInfo({ game }: GameDetailInfoProps) {
     {
       label: '권장 연령',
       value: age ? `${age}세 이상` : '알수없음',
-    },
-    {
-      label: '출시년도',
-      value: formatDate(created_at) || '알수없음',
     },
   ];
 

--- a/src/components/game/detail/SimilarGameItem.tsx
+++ b/src/components/game/detail/SimilarGameItem.tsx
@@ -21,7 +21,7 @@ export default function SimilarGameItem({
       href={`/games/${gameId}`}
       className="group flex items-center gap-4"
     >
-      <div className="relative aspect-[4/5] w-25 overflow-hidden rounded-md bg-gray-100">
+      <div className="relative aspect-[4/5] w-24 shrink-0 overflow-hidden rounded-md bg-gray-100">
         <Image
           src={thumbnailUrl}
           alt={title}
@@ -31,8 +31,8 @@ export default function SimilarGameItem({
         />
       </div>
 
-      <div>
-        <h3 className="mb-2.5 truncate text-base font-semibold">{title}</h3>
+      <div className="w-full min-w-0">
+        <h3 className="mb-2.5 line-clamp-2 text-base font-semibold">{title}</h3>
 
         <div className="flex items-center gap-2">
           <RiStarFill className="h-4 w-4 text-gray-300" />

--- a/src/components/game/detail/SimilarGameList.tsx
+++ b/src/components/game/detail/SimilarGameList.tsx
@@ -1,26 +1,40 @@
-import { fetcher } from '@/lib/fetcher';
-import { GameListItem } from '@/types/game/game';
+import { GameListResponse } from '@/types/game/game';
+import { useQuery } from '@tanstack/react-query';
 import SimilarGameItem from './SimilarGameItem';
-
 interface SimilarGameListProps {
   genre: string;
 }
-interface GameListResponse {
-  count: number;
-  next: number | null;
-  previous: number | null;
-  results: GameListItem[];
-}
 
-async function getSimilarGames(genre = '전략') {
-  const response = await fetcher<GameListResponse>(`/games/?genres=${genre}`);
-  console.log('similar', response);
-  return response.results;
-}
-export default async function SimilarGameList({ genre }: SimilarGameListProps) {
-  const similarGames = await getSimilarGames(genre);
+export default function SimilarGameList({ genre }: SimilarGameListProps) {
+  // const similarGames = await getSimilarGames(genre);
+  const {
+    data: similarGames,
+    isLoading,
+    isError,
+  } = useQuery({
+    queryKey: ['similar', genre],
+    queryFn: async () => {
+      const res = await fetch(`/api/games?genres=${genre}&page_size=4`);
 
-  if (similarGames.length === 0) {
+      const data: GameListResponse = await res.json();
+      return data.results;
+    },
+  });
+
+  if (isLoading) {
+    return (
+      <p className="text-sm text-gray-500">비슷한 게임을 불러오는 중...</p>
+    );
+  }
+
+  if (isError) {
+    return (
+      <p className="text-sm text-red-500">
+        게임을 불러오는 중 오류가 발생했습니다.
+      </p>
+    );
+  }
+  if (!similarGames || similarGames.length === 0) {
     return <p className="text-sm text-gray-500">비슷한 게임이 없습니다.</p>;
   }
   return (

--- a/src/types/game/game.ts
+++ b/src/types/game/game.ts
@@ -21,7 +21,7 @@ export interface GameDetail extends GameBase {
   age: number;
   min_players: number;
   max_players: number;
-  playtime_minutes: number;
+  play_time: number;
   is_liked: boolean;
   created_at: string;
   updated_at: string;

--- a/src/utils/formatDifficulty.ts
+++ b/src/utils/formatDifficulty.ts
@@ -3,7 +3,7 @@ export function formatDifficulty(difficulty?: string): number {
   switch (difficulty) {
     case '쉬움':
       return 1;
-    case '보통':
+    case '중급':
       return 2;
     case '어려움':
       return 3;


### PR DESCRIPTION
## 🔗 관련 이슈

- Closes #115

## ✨ 작업 개요
게임상세페이지 백엔드 데이터 일치 작업 


## ✅ 작업 상세 내용
- 비슷한 게임 목록 컴포넌트 CSR 및 React Query 적용 
    - GameDetailBottomSection에서 SimilarGameList 활성화
    - SimilarGameList를 CSR 컴포넌트로 전환
    - TanStack Query의 useQuery 적용하여 genre 기반 API 호출
    - 로딩/에러/빈 목록 상태에 따른 사용자 피드백 문구 추가
    - SimilarGameItem 스타일 개선 (썸네일 사이즈, 텍스트 라인클램프 등)

- formatDifficulty 유틸 case "중급" 수정

- GameDetailInfo에 play_time 필드 반영 및 불필요한 필드 제거
    - playtime_minutes → play_time으로 필드 명칭 통일
    - created_at(출시년도) 정보 및 formatDate 유틸 제거
    - GameDetail 타입 및 관련 컴포넌트에 일관성 있게 적용
    - 알 수 없는 값에 대한 기본 문구는 기존 방식 유지

## 스크린샷
<img width="1077" height="789" alt="image" src="https://github.com/user-attachments/assets/608ea8e8-4350-4546-8cdd-45fb8b22c9ff" />
